### PR TITLE
Add 404 fallback for legacy exec endpoint format

### DIFF
--- a/client.go
+++ b/client.go
@@ -119,10 +119,12 @@ func (c *Client) supportsPathAttach() bool {
 	return supportsPathAttach(c.SpriteVersion())
 }
 
-// FetchVersion makes a lightweight API call to capture the server version.
+// FetchVersion makes a lightweight API call to capture the sprite's version.
 // This is called automatically before attach operations if the version is unknown.
-func (c *Client) FetchVersion(ctx context.Context) error {
-	url := fmt.Sprintf("%s/v1/sprites", c.baseURL)
+// The spriteName parameter is required to route the request to the specific sprite,
+// since each sprite has its own version.
+func (c *Client) FetchVersion(ctx context.Context, spriteName string) error {
+	url := fmt.Sprintf("%s/v1/sprites/%s/exec", c.baseURL, spriteName)
 
 	req, err := http.NewRequestWithContext(ctx, "HEAD", url, nil)
 	if err != nil {

--- a/sprite.go
+++ b/sprite.go
@@ -29,6 +29,10 @@ type Sprite struct {
 	PrimaryRegion    string
 	URL              string
 	URLSettings      *URLSettings
+
+	// useLegacyExecEndpoint is set to true if /exec/:id returned 404,
+	// indicating this sprite requires the legacy /exec?id= format.
+	useLegacyExecEndpoint bool
 }
 
 // Name returns the sprite's name.


### PR DESCRIPTION
## Summary
Fix attach command for sprites that don't support `/exec/:id` endpoint format.

## Changes
- `FetchVersion()` now takes `spriteName` and calls `/v1/sprites/{name}/exec` to get the specific sprite's version (not the platform version)
- Add `useLegacyExecEndpoint` field to `Sprite` to cache endpoint preference
- On 404 from `/exec/:id`, automatically fall back to `/exec?id=` format
- Force TTY=true when using legacy endpoint (old sprites don't report TTY reliably)
- Add test cases for both endpoint formats
