### PR TITLE
Return structured APIError from websocket dial failures

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -38,6 +38,9 @@ type APIError struct {
 	// UpgradeAvailable indicates if an upgrade is available
 	UpgradeAvailable bool `json:"upgrade_available,omitempty"`
 
+	// UpgradeURL is the URL to upgrade the account (for rate limit errors)
+	UpgradeURL string `json:"upgrade_url,omitempty"`
+
 	// StatusCode is the HTTP status code (not from JSON, set by parser)
 	StatusCode int `json:"-"`
 


### PR DESCRIPTION
When the websocket handshake fails with an HTTP error response, parse the body as an APIError instead of embedding raw JSON in the error string. This allows callers to access structured error information (error code, limits, upgrade URL) directly.

- Add UpgradeURL field to APIError for rate limit upgrade links
- Use parseAPIError() in websocket.go when dial fails with HTTP error