### PR TITLE
Re-add control WebSocket support

### DIFF
--- a/client.go
+++ b/client.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -20,6 +21,16 @@ type Client struct {
 	token         string
 	httpClient    *http.Client
 	spriteVersion atomic.Value // stores string, empty until captured from response header
+
+	// Control connection pools per sprite
+	poolsMu sync.RWMutex
+	pools   map[string]*controlPool
+
+	// Control initialization behavior
+	controlInitTimeout time.Duration
+
+	// disableControl prevents automatic control connection usage
+	disableControl bool
 }
 
 // Option is a functional option for configuring the SDK client.
@@ -33,6 +44,8 @@ func New(token string, opts ...Option) *Client {
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
+		pools:              make(map[string]*controlPool),
+		controlInitTimeout: 2 * time.Second,
 	}
 
 	for _, opt := range opts {
@@ -75,23 +88,48 @@ func WithHTTPClient(client *http.Client) Option {
 	}
 }
 
+// WithControlInitTimeout sets how long Sprite() will wait to establish a control connection
+// before falling back to legacy endpoint API for that Sprite. Defaults to 2s.
+func WithControlInitTimeout(d time.Duration) Option {
+	return func(c *Client) {
+		c.controlInitTimeout = d
+	}
+}
+
+// WithDisableControl prevents the SDK from using control connections.
+// When disabled, all operations use direct WebSocket connections per request.
+func WithDisableControl() Option {
+	return func(c *Client) {
+		c.disableControl = true
+	}
+}
+
 // Sprite returns a Sprite instance for the given name.
 // This doesn't create the sprite on the server, it just returns a handle to work with it.
 func (c *Client) Sprite(name string) *Sprite {
-	return &Sprite{
+	s := &Sprite{
 		name:   name,
 		client: c,
 	}
+	// Attempt to establish control connection upfront; block until success or timeout/404
+	ctx, cancel := context.WithTimeout(context.Background(), c.controlInitTimeout)
+	defer cancel()
+	s.ensureControlSupport(ctx)
+	return s
 }
 
 // SpriteWithOrg returns a Sprite instance for the given name with organization information.
 // This doesn't create the sprite on the server, it just returns a handle to work with it.
 func (c *Client) SpriteWithOrg(name string, org *OrganizationInfo) *Sprite {
-	return &Sprite{
+	s := &Sprite{
 		name:   name,
 		client: c,
 		org:    org,
 	}
+	ctx, cancel := context.WithTimeout(context.Background(), c.controlInitTimeout)
+	defer cancel()
+	s.ensureControlSupport(ctx)
+	return s
 }
 
 // Create creates a new sprite with the given name and returns a handle to it.
@@ -264,6 +302,43 @@ func (c *Client) signalSession(ctx context.Context, spriteName, sessionID, signa
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("signal failed (status %d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
+
+	return nil
+}
+
+// getOrCreatePool gets or creates a control pool for the given sprite
+func (c *Client) getOrCreatePool(spriteName string) *controlPool {
+	c.poolsMu.RLock()
+	pool, exists := c.pools[spriteName]
+	c.poolsMu.RUnlock()
+
+	if exists {
+		return pool
+	}
+
+	c.poolsMu.Lock()
+	defer c.poolsMu.Unlock()
+
+	// Check again in case another goroutine created it
+	pool, exists = c.pools[spriteName]
+	if exists {
+		return pool
+	}
+
+	pool = newControlPool(c, spriteName)
+	c.pools[spriteName] = pool
+	return pool
+}
+
+// Close closes the client and all pooled connections
+func (c *Client) Close() error {
+	c.poolsMu.Lock()
+	defer c.poolsMu.Unlock()
+
+	for _, pool := range c.pools {
+		pool.close()
+	}
+	c.pools = nil
 
 	return nil
 }

--- a/control_pool.go
+++ b/control_pool.go
@@ -1,0 +1,357 @@
+package sprites
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	// maxPoolSize is a sanity cap; checkout fails if pool is full
+	maxPoolSize = 100
+	// poolDrainThreshold: when checkin and size > this, drain idle conns
+	poolDrainThreshold = 20
+	// poolDrainTarget: drain down to this many conns when draining
+	poolDrainTarget = 10
+
+	dialTimeout     = 5 * time.Second
+	keepAliveWindow = 30 * time.Second
+)
+
+// controlPool manages a pool of control WebSocket connections for a sprite
+type controlPool struct {
+	client     *Client
+	spriteName string
+	mu         sync.Mutex
+	conns      []*controlConn
+	closed     bool
+}
+
+// controlConn represents a control WebSocket connection
+type controlConn struct {
+	ws        *websocket.Conn
+	mu        sync.Mutex
+	busy      bool
+	lastUsed  time.Time
+	ctx       context.Context
+	cancel    context.CancelFunc
+	readCh    chan controlMessage
+	closedCh  chan struct{}
+	closeOnce sync.Once
+}
+
+// controlMessage represents a message on the control connection
+type controlMessage struct {
+	MessageType int    // WebSocket message type (binary or text)
+	Data        []byte // Raw message data
+}
+
+// newControlPool creates a new control connection pool for a sprite
+func newControlPool(client *Client, spriteName string) *controlPool {
+	return &controlPool{
+		client:     client,
+		spriteName: spriteName,
+		conns:      make([]*controlConn, 0, 32),
+	}
+}
+
+// checkout gets an idle connection from the pool, or creates a new one if needed
+func (p *controlPool) checkout(ctx context.Context) (*controlConn, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed {
+		return nil, fmt.Errorf("pool is closed")
+	}
+
+	// Try to find an idle connection
+	for i, conn := range p.conns {
+		conn.mu.Lock()
+		if !conn.busy {
+			// Check if connection is still alive
+			select {
+			case <-conn.closedCh:
+				// Connection is closed, remove it
+				conn.mu.Unlock()
+				p.conns = append(p.conns[:i], p.conns[i+1:]...)
+				dbg("sprites: removed closed control conn", "sprite", p.spriteName, "pool", len(p.conns))
+				continue
+			default:
+			}
+
+			conn.busy = true
+			conn.mu.Unlock()
+			dbg("sprites: checkout control conn", "sprite", p.spriteName, "pool", len(p.conns))
+			return conn, nil
+		}
+		conn.mu.Unlock()
+	}
+
+	// No idle connections, create a new one if under sanity limit
+	if len(p.conns) < maxPoolSize {
+		conn, err := p.dial(ctx)
+		if err != nil {
+			return nil, err
+		}
+		conn.busy = true
+		p.conns = append(p.conns, conn)
+		dbg("sprites: dialed new control conn", "sprite", p.spriteName, "pool", len(p.conns))
+		return conn, nil
+	}
+
+	return nil, fmt.Errorf("no available connections in pool (at cap %d)", maxPoolSize)
+}
+
+// checkin returns a connection to the pool and may drain idle conns if pool is large
+func (p *controlPool) checkin(conn *controlConn) {
+	if conn == nil {
+		return
+	}
+
+	conn.mu.Lock()
+	conn.busy = false
+	conn.lastUsed = time.Now()
+	conn.mu.Unlock()
+
+	dbg("sprites: checkin control conn", "sprite", p.spriteName, "idle_at", conn.lastUsed.Unix())
+
+	p.mu.Lock()
+	p.tryDrainLocked()
+	p.mu.Unlock()
+}
+
+// tryDrainLocked removes idle connections when the pool is large and idle.
+// Caller must hold p.mu.
+func (p *controlPool) tryDrainLocked() {
+	if p.closed || len(p.conns) <= poolDrainThreshold {
+		return
+	}
+	type idleConn struct {
+		conn     *controlConn
+		lastUsed time.Time
+	}
+	var idles []idleConn
+	for _, c := range p.conns {
+		c.mu.Lock()
+		if !c.busy {
+			select {
+			case <-c.closedCh:
+				c.mu.Unlock()
+				continue
+			default:
+			}
+			idles = append(idles, idleConn{conn: c, lastUsed: c.lastUsed})
+		}
+		c.mu.Unlock()
+	}
+	toClose := len(p.conns) - poolDrainTarget
+	if toClose <= 0 || len(idles) == 0 {
+		return
+	}
+	if toClose > len(idles) {
+		toClose = len(idles)
+	}
+	sort.Slice(idles, func(i, j int) bool { return idles[i].lastUsed.Before(idles[j].lastUsed) })
+	closeSet := make(map[*controlConn]bool, toClose)
+	for i := 0; i < toClose; i++ {
+		closeSet[idles[i].conn] = true
+	}
+	for _, c := range p.conns {
+		if closeSet[c] {
+			c.close()
+		}
+	}
+	newConns := make([]*controlConn, 0, len(p.conns)-toClose)
+	for _, c := range p.conns {
+		if !closeSet[c] {
+			newConns = append(newConns, c)
+		}
+	}
+	p.conns = newConns
+	dbg("sprites: drained control pool", "sprite", p.spriteName, "pool_size", len(p.conns))
+}
+
+// dial creates a new control WebSocket connection
+func (p *controlPool) dial(ctx context.Context) (*controlConn, error) {
+	wsURL, err := p.buildControlURL()
+	if err != nil {
+		return nil, err
+	}
+
+	// Set up WebSocket dialer
+	dialer := &websocket.Dialer{
+		ReadBufferSize:   1024 * 1024, // 1MB
+		WriteBufferSize:  1024 * 1024, // 1MB
+		HandshakeTimeout: dialTimeout,
+	}
+
+	// Add TLS config if needed
+	if wsURL.Scheme == "wss" {
+		dialer.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: false,
+		}
+	}
+
+	// Set headers including auth and feature flag
+	header := http.Header{}
+	header.Set("Authorization", fmt.Sprintf("Bearer %s", p.client.token))
+	header.Set("User-Agent", "sprites-go-sdk/1.0")
+
+	// Connect to WebSocket
+	ws, resp, err := dialer.DialContext(ctx, wsURL.String(), header)
+	if err != nil {
+		// Enrich error with HTTP status/body when available
+		if resp != nil {
+			body, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("failed to dial control connection: %v (HTTP %d: %s)", err, resp.StatusCode, string(body))
+		}
+		return nil, fmt.Errorf("failed to dial control connection: %v", err)
+	}
+
+	connCtx, cancel := context.WithCancel(context.Background())
+
+	conn := &controlConn{
+		ws:       ws,
+		lastUsed: time.Now(),
+		ctx:      connCtx,
+		cancel:   cancel,
+		readCh:   make(chan controlMessage, 1000), // Large buffer to prevent blocking
+		closedCh: make(chan struct{}),
+	}
+
+	// Start read loop
+	go conn.readLoop()
+
+	dbg("sprites: created control conn", "sprite", p.spriteName, "pool_size", len(p.conns)+1)
+
+	return conn, nil
+}
+
+// buildControlURL builds the WebSocket URL for the control endpoint
+func (p *controlPool) buildControlURL() (*url.URL, error) {
+	baseURL := p.client.baseURL
+
+	// Convert HTTP(S) to WS(S)
+	if len(baseURL) >= 4 && baseURL[:4] == "http" {
+		baseURL = "ws" + baseURL[4:]
+	}
+
+	// Parse base URL
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid base URL: %w", err)
+	}
+
+	// Build path (no keep_alive in URL - that's in operation params)
+	u.Path = fmt.Sprintf("/v1/sprites/%s/control", p.spriteName)
+
+	return u, nil
+}
+
+// close closes all connections in the pool
+func (p *controlPool) close() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.closed = true
+	for _, conn := range p.conns {
+		conn.close()
+	}
+	p.conns = nil
+}
+
+// readLoop continuously reads messages from the control connection
+func (c *controlConn) readLoop() {
+	defer func() {
+		c.closeOnce.Do(func() {
+			close(c.closedCh)
+		})
+	}()
+
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		default:
+		}
+
+		// Read next message (could be JSON or binary)
+		messageType, data, err := c.ws.ReadMessage()
+		if err != nil {
+			// Connection closed or error
+			return
+		}
+
+		// Create message wrapper
+		msg := controlMessage{
+			MessageType: messageType,
+			Data:        data,
+		}
+
+		// Check if connection is busy (in use by an operation)
+		c.mu.Lock()
+		busy := c.busy
+		c.mu.Unlock()
+
+		if busy {
+			// Connection is busy - forward message to operation
+			select {
+			case c.readCh <- msg:
+			case <-c.ctx.Done():
+				return
+			}
+		} else {
+			// Connection is idle - handle control messages
+			if messageType == websocket.TextMessage {
+				// Try to parse as control message
+				var ctrlMsg struct {
+					Type string `json:"type"`
+				}
+				if json.Unmarshal(data, &ctrlMsg) == nil {
+					switch ctrlMsg.Type {
+					case "dial":
+						// Server is requesting a new connection - ignore in SDK
+					case "keepalive":
+						// Keepalive message - stay alive
+					default:
+						// Unknown message type
+					}
+				}
+			}
+			// Binary messages while idle are unexpected, ignore
+		}
+	}
+}
+
+// close closes the control connection
+func (c *controlConn) close() {
+	c.closeOnce.Do(func() {
+		c.cancel()
+		if c.ws != nil {
+			c.ws.Close()
+		}
+		close(c.closedCh)
+	})
+}
+
+// sendRelease sends a release message to return the connection to the pool
+func (c *controlConn) sendRelease() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	msg := map[string]interface{}{
+		"type": "release",
+	}
+
+	return c.ws.WriteJSON(msg)
+}

--- a/debug.go
+++ b/debug.go
@@ -1,0 +1,29 @@
+package sprites
+
+import (
+	"log/slog"
+	"os"
+	"sync/atomic"
+)
+
+var sdkDebug atomic.Bool
+
+func init() {
+	if v := os.Getenv("SPRITES_SDK_DEBUG"); v != "" && v != "0" && v != "false" {
+		sdkDebug.Store(true)
+	}
+}
+
+func dbg(msg string, args ...any) {
+	if sdkDebug.Load() {
+		slog.Default().Debug(msg, args...)
+	}
+}
+
+// SetDebug enables or disables SDK debug logging.
+// When enabled, debug messages are written via slog.Default().
+// This allows the calling application to control SDK debug output
+// programmatically (e.g., when a CLI debug flag is set).
+func SetDebug(enabled bool) {
+	sdkDebug.Store(enabled)
+}

--- a/filesystem_control.go
+++ b/filesystem_control.go
@@ -1,0 +1,758 @@
+package sprites
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"net/url"
+	"path"
+	"strconv"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// FsControlOption is a functional option for filesystem control operations
+type FsControlOption func(*fsControlOpts)
+
+type fsControlOpts struct {
+	workingDir    string
+	mode          fs.FileMode
+	mkdirParents  bool
+	asRoot        bool
+	recursive     bool
+	preserveAttrs bool
+	uid           int
+	gid           int
+	start         int64
+	end           int64
+}
+
+// WithFsWorkingDir sets the working directory for path resolution
+func WithFsWorkingDir(dir string) FsControlOption {
+	return func(o *fsControlOpts) {
+		o.workingDir = dir
+	}
+}
+
+// WithFsMode sets the file mode for write operations
+func WithFsMode(mode fs.FileMode) FsControlOption {
+	return func(o *fsControlOpts) {
+		o.mode = mode
+	}
+}
+
+// WithFsMkdirParents enables automatic parent directory creation
+func WithFsMkdirParents(enable bool) FsControlOption {
+	return func(o *fsControlOpts) {
+		o.mkdirParents = enable
+	}
+}
+
+// WithFsAsRoot runs the operation as root user
+func WithFsAsRoot(enable bool) FsControlOption {
+	return func(o *fsControlOpts) {
+		o.asRoot = enable
+	}
+}
+
+// WithFsRecursive enables recursive operation
+func WithFsRecursive(enable bool) FsControlOption {
+	return func(o *fsControlOpts) {
+		o.recursive = enable
+	}
+}
+
+// WithFsPreserveAttrs preserves file attributes during copy
+func WithFsPreserveAttrs(enable bool) FsControlOption {
+	return func(o *fsControlOpts) {
+		o.preserveAttrs = enable
+	}
+}
+
+// WithFsUid sets the user ID for chown operations
+func WithFsUid(uid int) FsControlOption {
+	return func(o *fsControlOpts) {
+		o.uid = uid
+	}
+}
+
+// WithFsGid sets the group ID for chown operations
+func WithFsGid(gid int) FsControlOption {
+	return func(o *fsControlOpts) {
+		o.gid = gid
+	}
+}
+
+// WithFsRange sets the byte range for read operations
+func WithFsRange(start, end int64) FsControlOption {
+	return func(o *fsControlOpts) {
+		o.start = start
+		o.end = end
+	}
+}
+
+// FsReadResult contains the result of a fs.read operation
+type FsReadResult struct {
+	Path string `json:"path"`
+	Size int64  `json:"size"`
+	Data []byte `json:"-"`
+}
+
+// FsWriteResult contains the result of a fs.write operation
+type FsWriteResult struct {
+	Path string `json:"path"`
+	Size int64  `json:"size"`
+	Mode string `json:"mode"`
+}
+
+// FsListResult contains the result of a fs.list operation
+type FsListResult struct {
+	Path    string    `json:"path"`
+	Entries []FsEntry `json:"entries"`
+	Count   int       `json:"count"`
+}
+
+// FsEntry represents a file or directory entry
+type FsEntry struct {
+	Name    string    `json:"name"`
+	Path    string    `json:"path"`
+	Type    string    `json:"type"`
+	Size    int64     `json:"size"`
+	Mode    string    `json:"mode"`
+	ModTime time.Time `json:"modTime"`
+	IsDir   bool      `json:"isDir"`
+}
+
+// FsDeleteResult contains the result of a fs.delete operation
+type FsDeleteResult struct {
+	Deleted []string `json:"deleted"`
+	Count   int      `json:"count"`
+}
+
+// FsChmodResult contains the result of a fs.chmod operation
+type FsChmodResult struct {
+	Affected []FsChmodEntry `json:"affected"`
+	Count    int            `json:"count"`
+}
+
+// FsChmodEntry represents a single chmod result
+type FsChmodEntry struct {
+	Path string `json:"path"`
+	Mode string `json:"mode"`
+}
+
+// FsChownResult contains the result of a fs.chown operation
+type FsChownResult struct {
+	Affected []FsChownEntry `json:"affected"`
+	Count    int            `json:"count"`
+}
+
+// FsChownEntry represents a single chown result
+type FsChownEntry struct {
+	Path string `json:"path"`
+	UID  int    `json:"uid"`
+	GID  int    `json:"gid"`
+}
+
+// FsCopyResult contains the result of a fs.copy operation
+type FsCopyResult struct {
+	Copied     []FsCopyEntry `json:"copied"`
+	Count      int           `json:"count"`
+	TotalBytes int64         `json:"totalBytes"`
+}
+
+// FsCopyEntry represents a single copy result
+type FsCopyEntry struct {
+	Source string `json:"source"`
+	Dest   string `json:"dest"`
+}
+
+// FsRenameResult contains the result of a fs.rename operation
+type FsRenameResult struct {
+	Source string `json:"source"`
+	Dest   string `json:"dest"`
+}
+
+// FsErrorResponse represents a filesystem operation error
+type FsErrorResponse struct {
+	Error string `json:"error"`
+	Code  string `json:"code,omitempty"`
+	Path  string `json:"path,omitempty"`
+}
+
+// FsReadControl reads a file using the control channel
+func (s *Sprite) FsReadControl(ctx context.Context, filePath string, opts ...FsControlOption) (*FsReadResult, error) {
+	o := &fsControlOpts{
+		workingDir: "/home/sprite",
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	// Build args
+	args := url.Values{}
+	args.Set("path", filePath)
+	if o.workingDir != "" {
+		args.Set("workingDir", o.workingDir)
+	}
+	if o.start > 0 {
+		args.Set("start", strconv.FormatInt(o.start, 10))
+	}
+	if o.end > 0 {
+		args.Set("end", strconv.FormatInt(o.end, 10))
+	}
+
+	// Execute operation
+	conn, err := s.checkoutControlConn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer s.checkinControlConn(conn)
+
+	if err := s.sendControlOp(conn, "fs.read", args); err != nil {
+		return nil, err
+	}
+
+	// Read JSON response first
+	_, data, err := conn.ws.ReadMessage()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	// Check for error response
+	var errResp FsErrorResponse
+	if json.Unmarshal(data, &errResp) == nil && errResp.Error != "" {
+		return nil, &fs.PathError{Op: "read", Path: filePath, Err: fmt.Errorf("%s (%s)", errResp.Error, errResp.Code)}
+	}
+
+	var result FsReadResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	// Read binary data
+	msgType, binaryData, err := conn.ws.ReadMessage()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file data: %w", err)
+	}
+	if msgType != websocket.BinaryMessage {
+		return nil, fmt.Errorf("expected binary data, got type %d", msgType)
+	}
+
+	result.Data = binaryData
+
+	// Wait for op.complete
+	if err := s.waitControlComplete(conn); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// FsWriteControl writes a file using the control channel
+func (s *Sprite) FsWriteControl(ctx context.Context, filePath string, data []byte, opts ...FsControlOption) (*FsWriteResult, error) {
+	o := &fsControlOpts{
+		workingDir:   "/home/sprite",
+		mode:         0644,
+		mkdirParents: true,
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	// Build args
+	args := url.Values{}
+	args.Set("path", filePath)
+	if o.workingDir != "" {
+		args.Set("workingDir", o.workingDir)
+	}
+	args.Set("mode", fmt.Sprintf("%04o", o.mode))
+	if !o.mkdirParents {
+		args.Set("mkdirParents", "false")
+	}
+	if o.asRoot {
+		args.Set("asRoot", "true")
+	}
+
+	// Execute operation
+	conn, err := s.checkoutControlConn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer s.checkinControlConn(conn)
+
+	if err := s.sendControlOp(conn, "fs.write", args); err != nil {
+		return nil, err
+	}
+
+	// Send binary data
+	if err := conn.ws.WriteMessage(websocket.BinaryMessage, data); err != nil {
+		return nil, fmt.Errorf("failed to send data: %w", err)
+	}
+
+	// Read response
+	_, respData, err := conn.ws.ReadMessage()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	// Check for error response
+	var errResp FsErrorResponse
+	if json.Unmarshal(respData, &errResp) == nil && errResp.Error != "" {
+		return nil, &fs.PathError{Op: "write", Path: filePath, Err: fmt.Errorf("%s (%s)", errResp.Error, errResp.Code)}
+	}
+
+	var result FsWriteResult
+	if err := json.Unmarshal(respData, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	// Wait for op.complete
+	if err := s.waitControlComplete(conn); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// FsListControl lists directory contents using the control channel
+func (s *Sprite) FsListControl(ctx context.Context, dirPath string, opts ...FsControlOption) (*FsListResult, error) {
+	o := &fsControlOpts{
+		workingDir: "/home/sprite",
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	// Build args
+	args := url.Values{}
+	if dirPath != "" {
+		args.Set("path", dirPath)
+	}
+	if o.workingDir != "" {
+		args.Set("workingDir", o.workingDir)
+	}
+	if o.recursive {
+		args.Set("recursive", "true")
+	}
+
+	// Execute operation
+	conn, err := s.checkoutControlConn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer s.checkinControlConn(conn)
+
+	if err := s.sendControlOp(conn, "fs.list", args); err != nil {
+		return nil, err
+	}
+
+	// Read response
+	_, respData, err := conn.ws.ReadMessage()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	// Check for error response
+	var errResp FsErrorResponse
+	if json.Unmarshal(respData, &errResp) == nil && errResp.Error != "" {
+		return nil, &fs.PathError{Op: "list", Path: dirPath, Err: fmt.Errorf("%s (%s)", errResp.Error, errResp.Code)}
+	}
+
+	var result FsListResult
+	if err := json.Unmarshal(respData, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	// Wait for op.complete
+	if err := s.waitControlComplete(conn); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// FsDeleteControl deletes a file or directory using the control channel
+func (s *Sprite) FsDeleteControl(ctx context.Context, filePath string, opts ...FsControlOption) (*FsDeleteResult, error) {
+	o := &fsControlOpts{
+		workingDir: "/home/sprite",
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	// Build args
+	args := url.Values{}
+	args.Set("path", filePath)
+	if o.workingDir != "" {
+		args.Set("workingDir", o.workingDir)
+	}
+	if o.recursive {
+		args.Set("recursive", "true")
+	}
+
+	// Execute operation
+	conn, err := s.checkoutControlConn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer s.checkinControlConn(conn)
+
+	if err := s.sendControlOp(conn, "fs.delete", args); err != nil {
+		return nil, err
+	}
+
+	// Read response
+	_, respData, err := conn.ws.ReadMessage()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	// Check for error response
+	var errResp FsErrorResponse
+	if json.Unmarshal(respData, &errResp) == nil && errResp.Error != "" {
+		return nil, &fs.PathError{Op: "delete", Path: filePath, Err: fmt.Errorf("%s (%s)", errResp.Error, errResp.Code)}
+	}
+
+	var result FsDeleteResult
+	if err := json.Unmarshal(respData, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	// Wait for op.complete
+	if err := s.waitControlComplete(conn); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// FsChmodControl changes file permissions using the control channel
+func (s *Sprite) FsChmodControl(ctx context.Context, filePath string, mode fs.FileMode, opts ...FsControlOption) (*FsChmodResult, error) {
+	o := &fsControlOpts{
+		workingDir: "/home/sprite",
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	// Build args
+	args := url.Values{}
+	args.Set("path", filePath)
+	args.Set("mode", fmt.Sprintf("%04o", mode))
+	if o.workingDir != "" {
+		args.Set("workingDir", o.workingDir)
+	}
+	if o.recursive {
+		args.Set("recursive", "true")
+	}
+
+	// Execute operation
+	conn, err := s.checkoutControlConn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer s.checkinControlConn(conn)
+
+	if err := s.sendControlOp(conn, "fs.chmod", args); err != nil {
+		return nil, err
+	}
+
+	// Read response
+	_, respData, err := conn.ws.ReadMessage()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	// Check for error response
+	var errResp FsErrorResponse
+	if json.Unmarshal(respData, &errResp) == nil && errResp.Error != "" {
+		return nil, &fs.PathError{Op: "chmod", Path: filePath, Err: fmt.Errorf("%s (%s)", errResp.Error, errResp.Code)}
+	}
+
+	var result FsChmodResult
+	if err := json.Unmarshal(respData, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	// Wait for op.complete
+	if err := s.waitControlComplete(conn); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// FsChownControl changes file ownership using the control channel
+func (s *Sprite) FsChownControl(ctx context.Context, filePath string, opts ...FsControlOption) (*FsChownResult, error) {
+	o := &fsControlOpts{
+		workingDir: "/home/sprite",
+		uid:        -1,
+		gid:        -1,
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	if o.uid == -1 && o.gid == -1 {
+		return nil, fmt.Errorf("at least one of uid or gid must be set")
+	}
+
+	// Build args
+	args := url.Values{}
+	args.Set("path", filePath)
+	if o.workingDir != "" {
+		args.Set("workingDir", o.workingDir)
+	}
+	if o.uid != -1 {
+		args.Set("uid", strconv.Itoa(o.uid))
+	}
+	if o.gid != -1 {
+		args.Set("gid", strconv.Itoa(o.gid))
+	}
+	if o.recursive {
+		args.Set("recursive", "true")
+	}
+
+	// Execute operation
+	conn, err := s.checkoutControlConn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer s.checkinControlConn(conn)
+
+	if err := s.sendControlOp(conn, "fs.chown", args); err != nil {
+		return nil, err
+	}
+
+	// Read response
+	_, respData, err := conn.ws.ReadMessage()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	// Check for error response
+	var errResp FsErrorResponse
+	if json.Unmarshal(respData, &errResp) == nil && errResp.Error != "" {
+		return nil, &fs.PathError{Op: "chown", Path: filePath, Err: fmt.Errorf("%s (%s)", errResp.Error, errResp.Code)}
+	}
+
+	var result FsChownResult
+	if err := json.Unmarshal(respData, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	// Wait for op.complete
+	if err := s.waitControlComplete(conn); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// FsCopyControl copies files using the control channel
+func (s *Sprite) FsCopyControl(ctx context.Context, source, dest string, opts ...FsControlOption) (*FsCopyResult, error) {
+	o := &fsControlOpts{
+		workingDir: "/home/sprite",
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	// Build args
+	args := url.Values{}
+	args.Set("source", source)
+	args.Set("dest", dest)
+	if o.workingDir != "" {
+		args.Set("workingDir", o.workingDir)
+	}
+	if o.recursive {
+		args.Set("recursive", "true")
+	}
+	if o.preserveAttrs {
+		args.Set("preserveAttrs", "true")
+	}
+	if o.asRoot {
+		args.Set("asRoot", "true")
+	}
+
+	// Execute operation
+	conn, err := s.checkoutControlConn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer s.checkinControlConn(conn)
+
+	if err := s.sendControlOp(conn, "fs.copy", args); err != nil {
+		return nil, err
+	}
+
+	// Read response
+	_, respData, err := conn.ws.ReadMessage()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	// Check for error response
+	var errResp FsErrorResponse
+	if json.Unmarshal(respData, &errResp) == nil && errResp.Error != "" {
+		return nil, &fs.PathError{Op: "copy", Path: source, Err: fmt.Errorf("%s (%s)", errResp.Error, errResp.Code)}
+	}
+
+	var result FsCopyResult
+	if err := json.Unmarshal(respData, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	// Wait for op.complete
+	if err := s.waitControlComplete(conn); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// FsRenameControl renames/moves a file using the control channel
+func (s *Sprite) FsRenameControl(ctx context.Context, source, dest string, opts ...FsControlOption) (*FsRenameResult, error) {
+	o := &fsControlOpts{
+		workingDir: "/home/sprite",
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	// Build args
+	args := url.Values{}
+	args.Set("source", source)
+	args.Set("dest", dest)
+	if o.workingDir != "" {
+		args.Set("workingDir", o.workingDir)
+	}
+
+	// Execute operation
+	conn, err := s.checkoutControlConn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer s.checkinControlConn(conn)
+
+	if err := s.sendControlOp(conn, "fs.rename", args); err != nil {
+		return nil, err
+	}
+
+	// Read response
+	_, respData, err := conn.ws.ReadMessage()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	// Check for error response
+	var errResp FsErrorResponse
+	if json.Unmarshal(respData, &errResp) == nil && errResp.Error != "" {
+		return nil, &fs.PathError{Op: "rename", Path: source, Err: fmt.Errorf("%s (%s)", errResp.Error, errResp.Code)}
+	}
+
+	var result FsRenameResult
+	if err := json.Unmarshal(respData, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	// Wait for op.complete
+	if err := s.waitControlComplete(conn); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// FsStatControl returns file info using the control channel (via fs.list)
+func (s *Sprite) FsStatControl(ctx context.Context, filePath string, opts ...FsControlOption) (*FsEntry, error) {
+	result, err := s.FsListControl(ctx, filePath, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(result.Entries) == 0 {
+		return nil, &fs.PathError{Op: "stat", Path: filePath, Err: fs.ErrNotExist}
+	}
+
+	// Return info for the path itself (first entry for the path)
+	entry := result.Entries[0]
+	if entry.Path == result.Path || entry.Name == path.Base(filePath) {
+		return &entry, nil
+	}
+
+	// If listing a directory, return the directory info
+	return &FsEntry{
+		Name:  path.Base(result.Path),
+		Path:  result.Path,
+		IsDir: true,
+		Type:  "directory",
+	}, nil
+}
+
+// Helper methods for control channel operations
+
+func (s *Sprite) checkoutControlConn(ctx context.Context) (*controlConn, error) {
+	if !s.supportsControl {
+		return nil, fmt.Errorf("sprite does not support control connections")
+	}
+
+	pool := s.client.getOrCreatePool(s.name)
+	return pool.checkout(ctx)
+}
+
+func (s *Sprite) checkinControlConn(conn *controlConn) {
+	if conn == nil {
+		return
+	}
+	// Send release message
+	conn.sendRelease()
+
+	pool := s.client.getOrCreatePool(s.name)
+	pool.checkin(conn)
+}
+
+func (s *Sprite) sendControlOp(conn *controlConn, op string, args url.Values) error {
+	// Build op.start message
+	msg := map[string]interface{}{
+		"type": "op.start",
+		"op":   op,
+		"args": args.Encode(),
+	}
+
+	return conn.ws.WriteJSON(msg)
+}
+
+func (s *Sprite) waitControlComplete(conn *controlConn) error {
+	// Read until we get op.complete or op.error
+	for {
+		_, data, err := conn.ws.ReadMessage()
+		if err != nil {
+			return fmt.Errorf("failed to read control message: %w", err)
+		}
+
+		var msg struct {
+			Type string          `json:"type"`
+			Args json.RawMessage `json:"args,omitempty"`
+		}
+		if err := json.Unmarshal(data, &msg); err != nil {
+			continue // Not a control message
+		}
+
+		switch msg.Type {
+		case "op.complete":
+			return nil
+		case "op.error":
+			var errArgs struct {
+				Error string `json:"error"`
+			}
+			if json.Unmarshal(msg.Args, &errArgs) == nil {
+				return fmt.Errorf("operation failed: %s", errArgs.Error)
+			}
+			return fmt.Errorf("operation failed")
+		}
+	}
+}

--- a/proxy.go
+++ b/proxy.go
@@ -161,36 +161,41 @@ func (ps *ProxySession) acceptLoop() {
 func (ps *ProxySession) handleConnection(localConn net.Conn) {
 	defer localConn.Close()
 
-	// Build WebSocket URL for proxy
-	wsURL, err := ps.buildProxyURL()
-	if err != nil {
-		return
-	}
+	// Check if sprite supports control connections (lazy check on first use)
+	sprite := ps.client.Sprite(ps.spriteName)
+	sprite.ensureControlSupport(ps.ctx)
 
-	// Set up WebSocket dialer
-	dialer := &websocket.Dialer{
-		ReadBufferSize:  1024 * 1024, // 1MB
-		WriteBufferSize: 1024 * 1024, // 1MB
-	}
+	var wsConn *websocket.Conn
+	var controlConn *controlConn
+	usingControl := false
 
-	// Add TLS config if needed
-	if wsURL.Scheme == "wss" {
-		dialer.TLSClientConfig = &tls.Config{
-			InsecureSkipVerify: false,
+	if sprite.supportsControl {
+		// Try to use control connection
+		pool := ps.client.getOrCreatePool(ps.spriteName)
+		var err error
+		controlConn, err = pool.checkout(ps.ctx)
+
+		if err == nil && controlConn != nil {
+			// Successfully got a control connection
+			wsConn = controlConn.ws
+			usingControl = true
+			defer func() {
+				// Send release message and return to pool
+				controlConn.sendRelease()
+				pool.checkin(controlConn)
+			}()
 		}
 	}
 
-	// Set headers including auth
-	header := http.Header{}
-	header.Set("Authorization", fmt.Sprintf("Bearer %s", ps.client.token))
-	header.Set("User-Agent", "sprites-go-sdk/1.0")
-
-	// Connect to WebSocket
-	wsConn, _, err := dialer.DialContext(ps.ctx, wsURL.String(), header)
-	if err != nil {
-		return
+	if !usingControl {
+		// Fall back to direct WebSocket connection (legacy path or control unavailable)
+		var err error
+		wsConn, err = ps.dialDirectWebSocket()
+		if err != nil {
+			return
+		}
+		defer wsConn.Close()
 	}
-	defer wsConn.Close()
 
 	// Send initialization message
 	// Use specified RemoteHost if provided, otherwise default to "localhost"
@@ -198,13 +203,30 @@ func (ps *ProxySession) handleConnection(localConn net.Conn) {
 	if host == "" {
 		host = "localhost"
 	}
-	initMsg := ProxyInitMessage{
-		Host: host,
-		Port: ps.RemotePort,
-	}
 
-	if err := wsConn.WriteJSON(&initMsg); err != nil {
-		return
+	if usingControl {
+		// Using control connection - send operation start message with keep_alive
+		startMsg := map[string]interface{}{
+			"type":      "start",
+			"operation": "proxy",
+			"params": map[string]interface{}{
+				"host":       host,
+				"port":       ps.RemotePort,
+				"keep_alive": true,
+			},
+		}
+		if err := wsConn.WriteJSON(&startMsg); err != nil {
+			return
+		}
+	} else {
+		// Direct WebSocket - send init message
+		initMsg := ProxyInitMessage{
+			Host: host,
+			Port: ps.RemotePort,
+		}
+		if err := wsConn.WriteJSON(&initMsg); err != nil {
+			return
+		}
 	}
 
 	// Read response
@@ -276,7 +298,7 @@ func (ps *ProxySession) buildProxyURL() (*url.URL, error) {
 	baseURL := ps.client.baseURL
 
 	// Convert HTTP(S) to WS(S)
-	if baseURL[:4] == "http" {
+	if len(baseURL) >= 4 && baseURL[:4] == "http" {
 		baseURL = "ws" + baseURL[4:]
 	}
 
@@ -290,6 +312,42 @@ func (ps *ProxySession) buildProxyURL() (*url.URL, error) {
 	u.Path = fmt.Sprintf("/v1/sprites/%s/proxy", ps.spriteName)
 
 	return u, nil
+}
+
+// dialDirectWebSocket creates a direct WebSocket connection for proxy (legacy path)
+func (ps *ProxySession) dialDirectWebSocket() (*websocket.Conn, error) {
+	// Build WebSocket URL for proxy
+	wsURL, err := ps.buildProxyURL()
+	if err != nil {
+		return nil, err
+	}
+
+	// Set up WebSocket dialer
+	dialer := &websocket.Dialer{
+		ReadBufferSize:  1024 * 1024, // 1MB
+		WriteBufferSize: 1024 * 1024, // 1MB
+	}
+
+	// Add TLS config if needed
+	if wsURL.Scheme == "wss" {
+		dialer.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: false,
+		}
+	}
+
+	// Set headers including auth and feature flag
+	header := http.Header{}
+	header.Set("Authorization", fmt.Sprintf("Bearer %s", ps.client.token))
+	header.Set("User-Agent", "sprites-go-sdk/1.0")
+	header.Set("Sprite-Client-Features", "control")
+
+	// Connect to WebSocket
+	wsConn, _, err := dialer.DialContext(ps.ctx, wsURL.String(), header)
+	if err != nil {
+		return nil, err
+	}
+
+	return wsConn, nil
 }
 
 // Close closes the proxy session

--- a/sprite.go
+++ b/sprite.go
@@ -33,6 +33,10 @@ type Sprite struct {
 	// useLegacyExecEndpoint is set to true if /exec/:id returned 404,
 	// indicating this sprite requires the legacy /exec?id= format.
 	useLegacyExecEndpoint bool
+
+	// Control connection support
+	supportsControl bool
+	controlChecked  bool
 }
 
 // Name returns the sprite's name.
@@ -53,4 +57,48 @@ func (s *Sprite) Organization() *OrganizationInfo {
 // Destroy destroys the sprite.
 func (s *Sprite) Destroy() error {
 	return s.Delete(context.Background())
+}
+
+// ensureControlSupport checks if the sprite supports control connections
+// This is called lazily on first exec/proxy operation
+func (s *Sprite) ensureControlSupport(ctx context.Context) {
+	if s.controlChecked {
+		return
+	}
+	s.controlChecked = true
+
+	// If control is disabled at client level, skip the check
+	if s.client.disableControl {
+		dbg("sprites: control disabled by client option", "sprite", s.name)
+		return
+	}
+
+	// Try to establish a control connection to test support
+	pool := s.client.getOrCreatePool(s.name)
+	if url, err := pool.buildControlURL(); err == nil {
+		dbg("sprites: attempting control connect", "sprite", s.name, "url", url.String())
+	} else {
+		dbg("sprites: control url build failed", "sprite", s.name, "err", err)
+	}
+	conn, err := pool.dial(ctx)
+	if err != nil {
+		// Control connections not supported (404 or other error)
+		dbg("sprites: control not available", "sprite", s.name, "err", err)
+		s.supportsControl = false
+		return
+	}
+
+	// Success - control connections are supported
+	s.supportsControl = true
+	dbg("sprites: control supported", "sprite", s.name)
+
+	// Add this initial connection to the pool
+	conn.mu.Lock()
+	conn.busy = false
+	conn.mu.Unlock()
+
+	// Add the connection to the pool
+	pool.mu.Lock()
+	pool.conns = append(pool.conns, conn)
+	pool.mu.Unlock()
 }


### PR DESCRIPTION
## Summary
- Reverts the revert (e58114b) to restore control WebSocket support
- This re-adds the control connection pool, filesystem operations over control, and debug utilities

Blocked on fixing the underlying issue where SDKs fail when connecting to sprites without control connections.