### PR TITLE
Fix TTY exit code not being reported to callers

### DIFF
--- a/websocket.go
+++ b/websocket.go
@@ -505,6 +505,7 @@ func (c *wsCmd) runIO() {
 					if c.TextMessageHandler != nil {
 						c.TextMessageHandler(data)
 					}
+					c.receivedExit = true
 					select {
 					case c.exitChan <- msg.ExitCode:
 					default:
@@ -581,6 +582,7 @@ func (c *wsCmd) runIO() {
 					if c.TextMessageHandler != nil {
 						c.TextMessageHandler(data)
 					}
+					c.receivedExit = true
 					select {
 					case c.exitChan <- msg.ExitCode:
 					default:


### PR DESCRIPTION
## Summary

- Set `receivedExit = true` in both the PTY and non-PTY text message exit handlers
- Without this, `ExitCode()` always returns -1 for sessions that receive exit codes via JSON text messages, causing `Wait()` to report "connection closed" instead of the actual exit code
- The binary `StreamExit` handler already set this flag correctly, but the text message handlers were missing it

## Root cause

In `websocket.go`, the TTY read loop receives `{"type":"exit","exit_code":0}` as a text message and correctly sends the exit code to `exitChan`, but never sets `c.receivedExit = true`. The `ExitCode()` method checks this flag first and returns -1 if it's false, without checking the channel.