### PR TITLE
Add PrivateAccess field to URLSettings

### DIFF
--- a/types.go
+++ b/types.go
@@ -14,7 +14,8 @@ type SpriteConfig struct {
 
 // URLSettings represents URL authentication settings
 type URLSettings struct {
-	Auth string `json:"auth,omitempty"`
+	Auth          string `json:"auth,omitempty"`
+	PrivateAccess string `json:"private_access,omitempty"`
 }
 
 // SpriteInfo represents sprite information from the API


### PR DESCRIPTION
## Summary
- Adds `PrivateAccess` field to `URLSettings` struct
- Supports the new `private_access` sprite URL setting (`"admins"` or `"org_users"`)
- Backward compatible (`omitempty` — old servers ignore it)

## Related PRs
- superfly/ui-ex#4731 — membership access endpoint
- superfly/sprites-api#563 — auth logic and admin UI
- superfly/sprite-env#430 — CLI `--private-access` flag