### PR TITLE
Add WithNetDialContext for custom TCP dialer

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -31,6 +32,10 @@ type Client struct {
 
 	// disableControl prevents automatic control connection usage
 	disableControl bool
+
+	// netDialContext, when set, is used for all outbound TCP connections:
+	// both the HTTP client transport and gorilla WebSocket dialers.
+	netDialContext func(ctx context.Context, network, addr string) (net.Conn, error)
 }
 
 // Option is a functional option for configuring the SDK client.
@@ -101,6 +106,17 @@ func WithControlInitTimeout(d time.Duration) Option {
 func WithDisableControl() Option {
 	return func(c *Client) {
 		c.disableControl = true
+	}
+}
+
+// WithNetDialContext sets a custom dial function used for all outbound TCP
+// connections.
+func WithNetDialContext(fn func(ctx context.Context, network, addr string) (net.Conn, error)) Option {
+	return func(c *Client) {
+		c.netDialContext = fn
+		c.httpClient.Transport = &http.Transport{
+			DialContext: fn,
+		}
 	}
 }
 

--- a/control_pool.go
+++ b/control_pool.go
@@ -217,6 +217,9 @@ func (p *controlPool) dial(ctx context.Context) (*controlConn, error) {
 		WriteBufferSize:  1024 * 1024, // 1MB
 		HandshakeTimeout: dialTimeout,
 	}
+	if p.client.netDialContext != nil {
+		dialer.NetDialContext = p.client.netDialContext
+	}
 
 	// Add TLS config if needed
 	if wsURL.Scheme == "wss" {

--- a/exec.go
+++ b/exec.go
@@ -246,6 +246,7 @@ func (c *Cmd) Start() error {
 		args = c.Args[1:]
 	}
 	c.wsCmd = newWSCmdContext(c.ctx, req, c.Path, args...)
+	c.wsCmd.dialContext = c.sprite.client.netDialContext
 
 	// If using control connection, provide the existing WebSocket
 	if usingControl {
@@ -300,6 +301,7 @@ func (c *Cmd) Start() error {
 			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.sprite.client.token))
 
 			c.wsCmd = newWSCmdContext(c.ctx, req, c.Path, args...)
+			c.wsCmd.dialContext = c.sprite.client.netDialContext
 			c.setupIO()
 			c.wsCmd.Tty = c.tty
 			c.wsCmd.IsAttach = true

--- a/websocket.go
+++ b/websocket.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -81,6 +82,9 @@ type wsCmd struct {
 	usingControl bool
 	// controlConn is the control connection wrapper (for reading from readCh)
 	controlConn *controlConn
+
+	// dialContext, when set, is used as the gorilla dialer's NetDialContext.
+	dialContext func(ctx context.Context, network, addr string) (net.Conn, error)
 }
 
 // wsAdapter wraps a WebSocket connection for terminal communication
@@ -206,6 +210,9 @@ func (c *wsCmd) start() {
 		dialer.HandshakeTimeout = 30 * time.Second
 		dialer.ReadBufferSize = 1024 * 1024
 		dialer.WriteBufferSize = 1024 * 1024
+		if c.dialContext != nil {
+			dialer.NetDialContext = c.dialContext
+		}
 
 		if c.Request.URL.Scheme == "wss" {
 			dialer.TLSClientConfig = &tls.Config{}
@@ -480,46 +487,46 @@ func (c *wsCmd) runIO() {
 			switch messageType {
 			case websocket.BinaryMessage:
 				stdout.Write(data)
-		case websocket.TextMessage:
-			// Check for control messages on control connections
-			if len(data) >= len("control:") && string(data[:len("control:")]) == "control:" {
-				dbg("sprites: pty received control message", "data", string(data))
-				continue
-			}
-			// Parse message type
-			var msg struct {
-				Type      string `json:"type"`
-				SessionID string `json:"session_id,omitempty"`
-				ExitCode  int    `json:"exit_code,omitempty"`
-			}
-			if json.Unmarshal(data, &msg) == nil {
-				dbg("sprites: pty received text message", "type", msg.Type, "data", string(data))
-				switch msg.Type {
-				case "session_info":
-					if msg.SessionID != "" {
-						c.sessionID = msg.SessionID
-					}
-				case "exit":
-					dbg("sprites: pty exit", "code", msg.ExitCode)
-					// Call handler first so CLI can detect clean exit
-					if c.TextMessageHandler != nil {
-						c.TextMessageHandler(data)
-					}
-					c.receivedExit = true
-					select {
-					case c.exitChan <- msg.ExitCode:
-					default:
-					}
-					adapter.Close()
-					return
+			case websocket.TextMessage:
+				// Check for control messages on control connections
+				if len(data) >= len("control:") && string(data[:len("control:")]) == "control:" {
+					dbg("sprites: pty received control message", "data", string(data))
+					continue
 				}
-			} else {
-				dbg("sprites: pty received non-json text message", "data", string(data))
-			}
-			// Handle text messages (e.g., port notifications)
-			if c.TextMessageHandler != nil {
-				c.TextMessageHandler(data)
-			}
+				// Parse message type
+				var msg struct {
+					Type      string `json:"type"`
+					SessionID string `json:"session_id,omitempty"`
+					ExitCode  int    `json:"exit_code,omitempty"`
+				}
+				if json.Unmarshal(data, &msg) == nil {
+					dbg("sprites: pty received text message", "type", msg.Type, "data", string(data))
+					switch msg.Type {
+					case "session_info":
+						if msg.SessionID != "" {
+							c.sessionID = msg.SessionID
+						}
+					case "exit":
+						dbg("sprites: pty exit", "code", msg.ExitCode)
+						// Call handler first so CLI can detect clean exit
+						if c.TextMessageHandler != nil {
+							c.TextMessageHandler(data)
+						}
+						c.receivedExit = true
+						select {
+						case c.exitChan <- msg.ExitCode:
+						default:
+						}
+						adapter.Close()
+						return
+					}
+				} else {
+					dbg("sprites: pty received non-json text message", "data", string(data))
+				}
+				// Handle text messages (e.g., port notifications)
+				if c.TextMessageHandler != nil {
+					c.TextMessageHandler(data)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This option overrides the dialer used for both HTTP and WebSocket
connections. This enables using alternative network backends besides
the default TCP implementation from "net". 