### PR TITLE
fix: dropped proxy errors

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -194,11 +194,11 @@ func wsProxyHandshake(
 	// Race with ctx.Done in a goroutine
 	go func() {
 		var err error
-		if err := wsConn.WriteJSON(initMsg); err != nil {
+		if err = wsConn.WriteJSON(initMsg); err != nil {
 			err = fmt.Errorf("failed to send init message: %w", err)
 		} else {
 			// Read response
-			if err := wsConn.ReadJSON(&response); err != nil {
+			if err = wsConn.ReadJSON(&response); err != nil {
 				err = fmt.Errorf("failed to read response: %w", err)
 			} else if response.Status != "connected" {
 				err = fmt.Errorf("unexpected status: %s", response.Status)


### PR DESCRIPTION
This fixes multiple `err` variables that were being lost because they were being defined within the scope of `if` blocks because of the use of `:=`.