### PR TITLE
Add opt-in client-signals support

### DIFF
--- a/client.go
+++ b/client.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
+	clientsignals "github.com/superfly/client-signals"
 )
 
 // Client is the main SDK client for interacting with the sprite API.
@@ -38,6 +39,10 @@ type Client struct {
 	// netDialContext, when set, is used for all outbound TCP connections:
 	// both the HTTP client transport and gorilla WebSocket dialers.
 	netDialContext func(ctx context.Context, network, addr string) (net.Conn, error)
+
+	// clientSignals, when set via WithClientSignals, is attached to every
+	// outgoing HTTP request and WebSocket dial.
+	clientSignals *clientsignals.Signals
 }
 
 // Option is a functional option for configuring the SDK client.
@@ -72,6 +77,9 @@ func New(token string, opts ...Option) *Client {
 	transport := c.httpClient.Transport
 	if transport == nil {
 		transport = cleanhttp.DefaultPooledTransport()
+	}
+	if c.clientSignals != nil {
+		transport = c.clientSignals.WrapTransport(transport)
 	}
 	c.httpClient.Transport = &versionCapturingTransport{
 		wrapped:       transport,

--- a/client_signals.go
+++ b/client_signals.go
@@ -1,0 +1,41 @@
+package sprites
+
+import (
+	"net/http"
+	"strconv"
+
+	clientsignals "github.com/superfly/client-signals"
+)
+
+// WithClientSignals attaches coarse, privacy-safe client-signal headers
+// (interactive/CI/agent detection; see github.com/superfly/client-signals)
+// to every outgoing request the Client makes — both plain HTTP calls and
+// the WebSocket dials used for exec/proxy/control connections. Pass the
+// result of clientsignals.DetectOnce() (or Detect()), computed once by the
+// caller.
+//
+// Disabled by default; a nil sig is a no-op.
+func WithClientSignals(sig *clientsignals.Signals) Option {
+	return func(c *Client) {
+		c.clientSignals = sig
+	}
+}
+
+// applyClientSignalHeaders sets the same Fly-Client-* headers that
+// clientsignals.Signals.WrapTransport applies to plain HTTP requests, for
+// use on WebSocket dials that bypass the Client's http.Client entirely. A
+// nil sig is a no-op.
+func applyClientSignalHeaders(header http.Header, sig *clientsignals.Signals) {
+	if sig == nil {
+		return
+	}
+	header.Set("Fly-Client-Interactive", strconv.FormatBool(sig.Interactive))
+	header.Set("Fly-Client-Parent", sig.Parent)
+	if sig.Agent != "" {
+		header.Set("Fly-Client-Agent", sig.Agent)
+		header.Set("Fly-Client-Agent-Source", sig.AgentSource)
+	}
+	if sig.CI {
+		header.Set("Fly-Client-CI", "true")
+	}
+}

--- a/client_signals.go
+++ b/client_signals.go
@@ -2,7 +2,6 @@ package sprites
 
 import (
 	"net/http"
-	"strconv"
 
 	clientsignals "github.com/superfly/client-signals"
 )
@@ -29,13 +28,5 @@ func applyClientSignalHeaders(header http.Header, sig *clientsignals.Signals) {
 	if sig == nil {
 		return
 	}
-	header.Set("Fly-Client-Interactive", strconv.FormatBool(sig.Interactive))
-	header.Set("Fly-Client-Parent", sig.Parent)
-	if sig.Agent != "" {
-		header.Set("Fly-Client-Agent", sig.Agent)
-		header.Set("Fly-Client-Agent-Source", sig.AgentSource)
-	}
-	if sig.CI {
-		header.Set("Fly-Client-CI", "true")
-	}
+	sig.ApplyHeaders(header)
 }

--- a/control_pool.go
+++ b/control_pool.go
@@ -234,6 +234,7 @@ func (p *controlPool) dial(ctx context.Context) (*controlConn, error) {
 	header := http.Header{}
 	header.Set("Authorization", fmt.Sprintf("Bearer %s", p.client.token))
 	header.Set("User-Agent", "sprites-go-sdk/1.0")
+	applyClientSignalHeaders(header, p.client.clientSignals)
 
 	// Connect to WebSocket
 	ws, resp, err := dialer.DialContext(ctx, wsURL.String(), header)

--- a/exec.go
+++ b/exec.go
@@ -239,6 +239,7 @@ func (c *Cmd) Start() error {
 		return err
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.sprite.client.token))
+	applyClientSignalHeaders(req.Header, c.sprite.client.clientSignals)
 
 	// Create WebSocket command
 	var args []string
@@ -299,6 +300,7 @@ func (c *Cmd) Start() error {
 				return err
 			}
 			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.sprite.client.token))
+			applyClientSignalHeaders(req.Header, c.sprite.client.clientSignals)
 
 			c.wsCmd = newWSCmdContext(c.ctx, req, c.Path, args...)
 			c.wsCmd.dialContext = c.sprite.client.netDialContext

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
-	github.com/superfly/client-signals v0.2.0
+	github.com/superfly/client-signals v0.2.1
 	golang.org/x/term v0.0.0-20220526004731-065cf7ba2467
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,13 @@
 module github.com/superfly/sprites-go
 
-go 1.24
+go 1.25.8
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
+	github.com/superfly/client-signals v0.2.0
 	golang.org/x/term v0.0.0-20220526004731-065cf7ba2467
 )
 
-require golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
+require golang.org/x/sys v0.46.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
-github.com/superfly/client-signals v0.2.0 h1:ecwb3sCWwZ55+gpinSi/3yl4/OSBAsqYpmMUxsbbNaU=
-github.com/superfly/client-signals v0.2.0/go.mod h1:YeQnlJ3sh9ptDyq1QZMKYv+AUW9Xuh77lRS9ULj+m2I=
+github.com/superfly/client-signals v0.2.1 h1:4rYN455gl4uhfgeuGwXta0f6U+L7QjZvVNUcVZcW/t8=
+github.com/superfly/client-signals v0.2.1/go.mod h1:YeQnlJ3sh9ptDyq1QZMKYv+AUW9Xuh77lRS9ULj+m2I=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20220526004731-065cf7ba2467 h1:CBpWXWQpIRjzmkkA+M7q9Fqnwd2mZr3AFqexg8YTfoM=

--- a/go.sum
+++ b/go.sum
@@ -4,7 +4,9 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+github.com/superfly/client-signals v0.2.0 h1:ecwb3sCWwZ55+gpinSi/3yl4/OSBAsqYpmMUxsbbNaU=
+github.com/superfly/client-signals v0.2.0/go.mod h1:YeQnlJ3sh9ptDyq1QZMKYv+AUW9Xuh77lRS9ULj+m2I=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20220526004731-065cf7ba2467 h1:CBpWXWQpIRjzmkkA+M7q9Fqnwd2mZr3AFqexg8YTfoM=
 golang.org/x/term v0.0.0-20220526004731-065cf7ba2467/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/proxy.go
+++ b/proxy.go
@@ -300,6 +300,7 @@ func (c *Client) dialProxyWebSocket(ctx context.Context, spriteName string) (*we
 	header.Set("Authorization", fmt.Sprintf("Bearer %s", c.token))
 	header.Set("User-Agent", "sprites-go-sdk/1.0")
 	header.Set("Sprite-Client-Features", "control")
+	applyClientSignalHeaders(header, c.clientSignals)
 
 	// Connect to WebSocket
 	wsConn, _, err := dialer.DialContext(ctx, wsURL.String(), header)


### PR DESCRIPTION
Adds a `WithClientSignals` option that attaches coarse, privacy-safe `Fly-Client-*` headers (interactive/CI/agent detection) to every outgoing request the SDK client makes.

## Context

`fly-go` recently gained a `clientsignals`-based mechanism (now split out into the standalone `github.com/superfly/client-signals` module) that lets the API side distinguish human-driven CLI usage from CI/agent-driven automation, via coarse signals like whether stdout is a terminal, a bucketed parent process, and a detected cooperating agent (e.g. Claude Code). The sprite CLI (`sprite-env`) already wires this into its fly-go/flaps clients and its own raw HTTP call sites, but most of its actual Sprites API traffic (exec, filesystem, checkpoints, sessions, proxy) goes through this SDK, which had no way to attach the same signals.

## Details

`WithClientSignals(sig *clientsignals.Signals)` is a new, opt-in `Option` (nil/unset is a no-op, so this is fully backward compatible). When set:
- The `Client`'s `http.Client` transport is wrapped the same way the existing version-capturing transport is, covering all plain HTTP calls (filesystem, checkpoints, sessions, management, etc).
- `applyClientSignalHeaders` sets the same `Fly-Client-*` headers directly on the WebSocket dials used for exec, proxy, and control-pool connections, since those bypass the `Client`'s `http.Client` entirely and build their own `http.Header` for the handshake.

Note: this bumps the module's minimum Go version from 1.24 to 1.25.8, since `client-signals` itself requires it.