### PR TITLE
Use hashicorp/go-cleanhttp instead of stdlib defaults

### DIFF
--- a/client.go
+++ b/client.go
@@ -59,6 +59,12 @@ func New(token string, opts ...Option) *Client {
 		opt(c)
 	}
 
+	// An Option (e.g. WithHTTPClient(nil)) may have left httpClient nil;
+	// restore a default before using it below.
+	if c.httpClient == nil {
+		c.httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+
 	// Wrap transport to capture Sprite-Version header from responses.
 	// Never fall back to the shared http.DefaultTransport: this is a
 	// long-lived client making repeated calls to the same host, so use
@@ -119,7 +125,21 @@ func WithDisableControl() Option {
 func WithNetDialContext(fn func(ctx context.Context, network, addr string) (net.Conn, error)) Option {
 	return func(c *Client) {
 		c.netDialContext = fn
-		transport := cleanhttp.DefaultPooledTransport()
+
+		if c.httpClient == nil {
+			c.httpClient = &http.Client{Timeout: 30 * time.Second}
+		}
+
+		// If an earlier option (e.g. WithHTTPClient) already configured a
+		// *http.Transport, clone it so we preserve its settings (TLS config,
+		// proxy, etc.) rather than discarding them; only fall back to a
+		// fresh cleanhttp transport if there's nothing to clone.
+		var transport *http.Transport
+		if existing, ok := c.httpClient.Transport.(*http.Transport); ok && existing != nil {
+			transport = existing.Clone()
+		} else {
+			transport = cleanhttp.DefaultPooledTransport()
+		}
 		transport.DialContext = fn
 		c.httpClient.Transport = transport
 	}

--- a/client.go
+++ b/client.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	cleanhttp "github.com/hashicorp/go-cleanhttp"
 )
 
 // Client is the main SDK client for interacting with the sprite API.
@@ -57,10 +59,13 @@ func New(token string, opts ...Option) *Client {
 		opt(c)
 	}
 
-	// Wrap transport to capture Sprite-Version header from responses
+	// Wrap transport to capture Sprite-Version header from responses.
+	// Never fall back to the shared http.DefaultTransport: this is a
+	// long-lived client making repeated calls to the same host, so use
+	// cleanhttp's non-shared, pooled transport instead.
 	transport := c.httpClient.Transport
 	if transport == nil {
-		transport = http.DefaultTransport
+		transport = cleanhttp.DefaultPooledTransport()
 	}
 	c.httpClient.Transport = &versionCapturingTransport{
 		wrapped:       transport,
@@ -114,9 +119,9 @@ func WithDisableControl() Option {
 func WithNetDialContext(fn func(ctx context.Context, network, addr string) (net.Conn, error)) Option {
 	return func(c *Client) {
 		c.netDialContext = fn
-		c.httpClient.Transport = &http.Transport{
-			DialContext: fn,
-		}
+		transport := cleanhttp.DefaultPooledTransport()
+		transport.DialContext = fn
+		c.httpClient.Transport = transport
 	}
 }
 
@@ -248,12 +253,15 @@ func CreateToken(ctx context.Context, flyMacaroon, orgSlug string, inviteCode st
 	// Force HTTP/1.1 to avoid HTTP/2 header size limits in Fly.io's edge proxy
 	// The edge proxy rejects HTTP/2 requests with large headers (>16KB) even though
 	// the backend supports much larger headers (256KB)
-	// Setting TLSNextProto to a non-nil empty map disables HTTP/2 in the transport
+	// Setting TLSNextProto to a non-nil empty map disables HTTP/2 in the transport.
+	// Start from cleanhttp's non-shared transport (rather than a bare
+	// &http.Transport{}) so this one-off request still gets sane defaults
+	// like proxy support.
+	transport := cleanhttp.DefaultTransport()
+	transport.TLSNextProto = make(map[string]func(authority string, c *tls.Conn) http.RoundTripper)
 	client := &http.Client{
-		Timeout: 30 * time.Second,
-		Transport: &http.Transport{
-			TLSNextProto: make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
-		},
+		Timeout:   30 * time.Second,
+		Transport: transport,
 	}
 	resp, err := client.Do(httpReq)
 	if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -1,7 +1,11 @@
 package sprites
 
 import (
+	"context"
+	"net"
+	"net/http"
 	"testing"
+	"time"
 )
 
 func TestClientOptions(t *testing.T) {
@@ -18,5 +22,93 @@ func TestClientOptions(t *testing.T) {
 	client = New("test-token", WithBaseURL("http://localhost:8080"))
 	if client.baseURL != "http://localhost:8080" {
 		t.Errorf("custom baseURL = %q, want %q", client.baseURL, "http://localhost:8080")
+	}
+}
+
+// unwrapTransport extracts the underlying *http.Transport from a Client's
+// httpClient, looking through the versionCapturingTransport wrapper.
+func unwrapTransport(t *testing.T, c *Client) *http.Transport {
+	t.Helper()
+
+	vct, ok := c.httpClient.Transport.(*versionCapturingTransport)
+	if !ok {
+		t.Fatalf("expected c.httpClient.Transport to be *versionCapturingTransport, got %T", c.httpClient.Transport)
+	}
+
+	transport, ok := vct.wrapped.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected wrapped transport to be *http.Transport, got %T", vct.wrapped)
+	}
+
+	return transport
+}
+
+func TestNew_DefaultTransportIsNotSharedGlobal(t *testing.T) {
+	c := New("test-token")
+
+	transport := unwrapTransport(t, c)
+
+	if transport == http.DefaultTransport {
+		t.Fatal("New() must not fall back to the shared http.DefaultTransport")
+	}
+	if transport.MaxIdleConnsPerHost <= 0 {
+		t.Fatalf("expected a pooled transport (MaxIdleConnsPerHost > 0), got %d", transport.MaxIdleConnsPerHost)
+	}
+	if transport.DisableKeepAlives {
+		t.Fatal("expected a pooled transport with keepalives enabled")
+	}
+}
+
+func TestNew_WithHTTPClientNilDoesNotPanic(t *testing.T) {
+	c := New("test-token", WithHTTPClient(nil))
+
+	if c.httpClient == nil {
+		t.Fatal("expected New() to restore a non-nil httpClient when WithHTTPClient(nil) is used")
+	}
+
+	transport := unwrapTransport(t, c)
+	if transport == http.DefaultTransport {
+		t.Fatal("New() must not fall back to the shared http.DefaultTransport")
+	}
+}
+
+func TestWithNetDialContext_NilHTTPClientDoesNotPanic(t *testing.T) {
+	fn := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return nil, nil
+	}
+
+	c := New("test-token", WithHTTPClient(nil), WithNetDialContext(fn))
+
+	transport := unwrapTransport(t, c)
+	if transport.DialContext == nil {
+		t.Fatal("expected DialContext to be set")
+	}
+}
+
+func TestWithNetDialContext_PreservesExistingTransportSettings(t *testing.T) {
+	const distinguishingTimeout = 42 * time.Second
+
+	customTransport := &http.Transport{
+		TLSHandshakeTimeout: distinguishingTimeout,
+	}
+	fn := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return nil, nil
+	}
+
+	c := New("test-token",
+		WithHTTPClient(&http.Client{Transport: customTransport}),
+		WithNetDialContext(fn),
+	)
+
+	transport := unwrapTransport(t, c)
+
+	if transport.TLSHandshakeTimeout != distinguishingTimeout {
+		t.Fatalf("expected WithNetDialContext to preserve the existing transport's TLSHandshakeTimeout, got %v", transport.TLSHandshakeTimeout)
+	}
+	if transport.DialContext == nil {
+		t.Fatal("expected DialContext to be set")
+	}
+	if transport == customTransport {
+		t.Fatal("expected WithNetDialContext to clone the existing transport, not mutate it in place")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24
 require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/gorilla/websocket v1.5.0
+	github.com/hashicorp/go-cleanhttp v0.5.2
 	golang.org/x/term v0.0.0-20220526004731-065cf7ba2467
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20220526004731-065cf7ba2467 h1:CBpWXWQpIRjzmkkA+M7q9Fqnwd2mZr3AFqexg8YTfoM=


### PR DESCRIPTION
Replaces every fallback to Go's shared `http.DefaultTransport` and every bare `&http.Transport{}` construction with `hashicorp/go-cleanhttp`'s non-shared equivalents.

## Context

Auditing every `http.NewRequest`/`http.NewRequestWithContext` call site (in the course of looking at why #23 has to reapply client-signal headers directly to WebSocket dials) turned up that most plain-HTTP call sites already funnel through `c.httpClient.Do(...)` or reuse `c.httpClient.Transport` — so they'd already inherit any transport wrapping (like #23's client-signals). But a few places construct their own transport independently of `c.httpClient`, and those fell back to Go's shared, globally-mutable `http.DefaultTransport`, or to a bare `&http.Transport{}` missing sane defaults like proxy support. Since values on `http.DefaultTransport`/`http.DefaultClient` are shared process-wide, relying on them (or building a transport from a zero value) risks exactly the kind of hard-to-debug cross-contamination `go-cleanhttp` exists to avoid.

## Details

- `New()`'s fallback when no custom `Transport`/`Option` is supplied now uses `cleanhttp.DefaultPooledTransport()` instead of `http.DefaultTransport` — this is a long-lived client making repeated calls to the same host, so connection pooling/keepalive matters (plain `cleanhttp.DefaultTransport()` disables both).
- `WithNetDialContext`'s custom transport now starts from `cleanhttp.DefaultPooledTransport()` with `DialContext` overridden, instead of a bare `&http.Transport{DialContext: fn}` that silently dropped proxy support and other defaults.
- `CreateToken`'s one-off bootstrap client (a package-level function with no `Client` to reuse) now starts from `cleanhttp.DefaultTransport()` with `TLSNextProto` overridden on top — preserving the existing HTTP/2-disable workaround for Fly.io's edge proxy — instead of a bare `&http.Transport{}` that silently ignored `HTTP_PROXY`/`HTTPS_PROXY`.

All other `http.Client`/`http.Transport` construction sites (the streaming clients in `checkpoint.go`/`services.go`) already reuse `c.httpClient.Transport` directly, so they inherit this change transitively with no further edits needed.

This is scoped narrowly to the transport/client layer; wiring client signals into `CreateToken` itself (the one remaining call site that doesn't have access to a `Client`/`Signals`) is left for a separate follow-up.