### PR TITLE
Add checks CI workflow and golangci-lint configuration

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,47 @@
+name: Checks
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.0
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9.2.1
+        with:
+          version: v2.11.3
+
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7.0.0
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+      - name: go mod download
+        run: go mod download
+      - name: go mod verify
+        run: go mod verify
+      - name: Run tests
+        run: go test ./...

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,6 +15,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  precommit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.0
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+      - uses: j178/prek-action@v2.0.5
+        with:
+          extra-args: --all-files --stage=manual
+
   golangci:
     name: lint
     runs-on: ubuntu-latest
@@ -24,8 +35,9 @@ jobs:
         with:
           go-version-file: "go.mod"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9.2.1
+        uses: golangci/golangci-lint-action@v9.3.0
         with:
+          # Keep golangci-lint version insync with .pre-commit-config.yaml
           version: v2.11.3
 
   test:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,61 @@
+version: "2"
+run:
+  issues-exit-code: 1
+  tests: true
+linters:
+  default: none
+  enable:
+    - gomodguard
+    - govet
+    - ineffassign
+    - staticcheck
+    - unconvert
+    - unused
+    - nlreturn
+    - bodyclose
+    - gocheckcompilerdirectives
+    - errname
+    - errchkjson
+  settings:
+    nlreturn:
+      block-size: 3
+    staticcheck:
+      checks:
+        - all
+        - -ST1003 # struct field ... should be ... (mostly acronyms such as Http -> HTTP)
+    gomodguard:
+      allowed:
+        modules:
+          - github.com/Masterminds/semver/v3
+          - github.com/gorilla/websocket
+          - github.com/hashicorp/go-cleanhttp
+          - github.com/superfly/client-signals
+        domains:
+          - golang.org
+      blocked:
+        modules:
+          - github.com/superfly/flyctl:
+              reason: "this SDK can not depend on flyctl project because it pulls tons of dependencies"
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofumpt
+  settings:
+    gofumpt:
+      module-path: github.com/superfly/sprites-go
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+
+  - repo: https://github.com/tekwizely/pre-commit-golang
+    rev: v1.0.0-rc.4
+    hooks:
+      - id: go-mod-tidy
+
+  # NOTE: This pre-commit hook is ignored when running on Github Workflow
+  # because goalngci-lint github action is much more useful than the pre-commit action.
+  # The trick is to run github action only for "manual" hook stage
+  - repo: https://github.com/golangci/golangci-lint
+    # Keep golangci-lint version in sync with .github/workflows/checks.yml
+    rev: v2.11.3
+    hooks:
+      - id: golangci-lint
+        stages: [pre-commit]
+        args:
+          - --max-issues-per-linter=0
+          - --max-same-issues=0

--- a/README.md
+++ b/README.md
@@ -19,24 +19,24 @@ package main
 import (
     "fmt"
     "log"
-    
+
     sprites "github.com/superfly/sprites-go"
 )
 
 func main() {
     // Create a client with authentication
     client := sprites.New("your-auth-token")
-    
+
     // Get a sprite handle
     sprite := client.Sprite("my-sprite")
-    
+
     // Run a command - just like exec.Command!
     cmd := sprite.Command("echo", "hello", "world")
     output, err := cmd.Output()
     if err != nil {
         log.Fatal(err)
     }
-    
+
     fmt.Printf("Output: %s", output)
 }
 ```
@@ -50,7 +50,7 @@ func main() {
 client := sprites.New("your-auth-token")
 
 // Or with custom base URL
-client := sprites.New("your-auth-token", 
+client := sprites.New("your-auth-token",
     sprites.WithBaseURL("http://localhost:8080"))
 
 // Get a sprite handle
@@ -114,7 +114,7 @@ if err != nil {
     log.Fatal(err)
 }
 
-// Get stdout pipe  
+// Get stdout pipe
 stdout, err := cmd.StdoutPipe()
 if err != nil {
     log.Fatal(err)
@@ -260,9 +260,9 @@ cmd.TextMessageHandler = func(data []byte) {
 
     switch notification.Type {
     case "port_opened":
-        fmt.Printf("Port %d opened on %s (PID %d)\n", 
+        fmt.Printf("Port %d opened on %s (PID %d)\n",
             notification.Port, notification.Address, notification.PID)
-        
+
         // Create proxy session with the specific address
         session, err := sprite.ProxyPorts(ctx, []sprites.PortMapping{
             {
@@ -275,17 +275,17 @@ cmd.TextMessageHandler = func(data []byte) {
             log.Printf("Failed to create proxy for port %d: %v", notification.Port, err)
             return
         }
-        
+
         mu.Lock()
         proxies[notification.Port] = session[0]
         mu.Unlock()
-        
-        fmt.Printf("Forwarding localhost:%d -> %s:%d\n", 
+
+        fmt.Printf("Forwarding localhost:%d -> %s:%d\n",
             notification.Port, notification.Address, notification.Port)
 
     case "port_closed":
         fmt.Printf("Port %d closed (PID %d)\n", notification.Port, notification.PID)
-        
+
         mu.Lock()
         if session, ok := proxies[notification.Port]; ok {
             session.Close()
@@ -321,42 +321,42 @@ import (
     "log"
     "strings"
     "time"
-    
+
     sprites "github.com/superfly/sprites-go"
 )
 
 func main() {
     // Create client with authentication
-    client := sprites.New("your-auth-token", 
+    client := sprites.New("your-auth-token",
         sprites.WithBaseURL("https://api.sprite.example.com"))
-    
+
     // Get a sprite handle
     sprite := client.Sprite("my-sprite")
-    
+
     // Example 1: Simple command with output
     output, err := sprite.Command("date").Output()
     if err != nil {
         log.Fatal(err)
     }
     fmt.Printf("Current date: %s", output)
-    
+
     // Example 2: Command with pipes and timeout
     ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
     defer cancel()
-    
+
     cmd := sprite.CommandContext(ctx, "grep", "-i", "error")
     cmd.Stdin = strings.NewReader("Line 1\nError on line 2\nLine 3\nAnother ERROR\n")
-    
+
     output, err = cmd.Output()
     if err != nil {
         log.Fatal(err)
     }
     fmt.Printf("Grep results:\n%s", output)
-    
+
     // Example 3: Interactive command with environment
     cmd = sprite.Command("bash", "-c", "echo Hello $USER from $HOSTNAME")
     cmd.Env = []string{"USER=sprite", "HOSTNAME=remote"}
-    
+
     output, err = cmd.Output()
     if err != nil {
         log.Fatal(err)
@@ -409,7 +409,7 @@ sprites, err := client.List()
 The `sprite.Cmd` type is designed to be a drop-in replacement for `exec.Cmd`. It implements the same methods with the same behavior:
 
 - `Run()` - Start and wait for completion
-- `Start()` - Start the command asynchronously  
+- `Start()` - Start the command asynchronously
 - `Wait()` - Wait for a started command to complete
 - `Output()` - Run and return stdout
 - `CombinedOutput()` - Run and return combined stdout/stderr

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -30,12 +30,12 @@ func (c *Client) CreateCheckpointWithComment(ctx context.Context, spriteName str
 	// Build URL
 	url := fmt.Sprintf("%s/v1/sprites/%s/checkpoint", c.baseURL, spriteName)
 
-    // Create request body (backward compatible if comment is empty)
-    payload := map[string]interface{}{}
-    if comment != "" {
-        payload["comment"] = comment
-    }
-    jsonData, err := json.Marshal(payload)
+	// Create request body (backward compatible if comment is empty)
+	payload := map[string]interface{}{}
+	if comment != "" {
+		payload["comment"] = comment
+	}
+	jsonData, err := json.Marshal(payload)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -74,17 +74,17 @@ func (c *Client) CreateCheckpointWithComment(ctx context.Context, spriteName str
 
 // CreateCheckpoint creates a new checkpoint for the sprite (no comment)
 func (c *Client) CreateCheckpoint(ctx context.Context, spriteName string) (*CheckpointStream, error) {
-    return c.CreateCheckpointWithComment(ctx, spriteName, "")
+	return c.CreateCheckpointWithComment(ctx, spriteName, "")
 }
 
 // CreateCheckpoint creates a new checkpoint for this sprite (no comment)
 func (s *Sprite) CreateCheckpoint(ctx context.Context) (*CheckpointStream, error) {
-    return s.client.CreateCheckpointWithComment(ctx, s.name, "")
+	return s.client.CreateCheckpointWithComment(ctx, s.name, "")
 }
 
 // CreateCheckpointWithComment creates a new checkpoint for this sprite with an optional comment
 func (s *Sprite) CreateCheckpointWithComment(ctx context.Context, comment string) (*CheckpointStream, error) {
-    return s.client.CreateCheckpointWithComment(ctx, s.name, comment)
+	return s.client.CreateCheckpointWithComment(ctx, s.name, comment)
 }
 
 // ListCheckpointsOptions contains options for listing checkpoints
@@ -254,6 +254,7 @@ func (cs *CheckpointStream) Next() (*StreamMessage, error) {
 		if err := cs.scanner.Err(); err != nil {
 			return nil, err
 		}
+
 		return nil, io.EOF
 	}
 
@@ -276,6 +277,7 @@ func (cs *CheckpointStream) Close() error {
 	if cs.reader != nil {
 		return cs.reader.Close()
 	}
+
 	return nil
 }
 
@@ -290,6 +292,7 @@ func (rs *RestoreStream) Next() (*StreamMessage, error) {
 		if err := rs.scanner.Err(); err != nil {
 			return nil, err
 		}
+
 		return nil, io.EOF
 	}
 
@@ -312,6 +315,7 @@ func (rs *RestoreStream) Close() error {
 	if rs.reader != nil {
 		return rs.reader.Close()
 	}
+
 	return nil
 }
 

--- a/client.go
+++ b/client.go
@@ -177,6 +177,7 @@ func (c *Client) Sprite(name string) *Sprite {
 	ctx, cancel := context.WithTimeout(context.Background(), c.controlInitTimeout)
 	defer cancel()
 	s.ensureControlSupport(ctx)
+
 	return s
 }
 
@@ -191,6 +192,7 @@ func (c *Client) SpriteWithOrg(name string, org *OrganizationInfo) *Sprite {
 	ctx, cancel := context.WithTimeout(context.Background(), c.controlInitTimeout)
 	defer cancel()
 	s.ensureControlSupport(ctx)
+
 	return s
 }
 
@@ -211,6 +213,7 @@ func (c *Client) SpriteVersion() string {
 	if v := c.spriteVersion.Load(); v != nil {
 		return v.(string)
 	}
+
 	return ""
 }
 
@@ -322,6 +325,7 @@ func CreateToken(ctx context.Context, flyMacaroon, orgSlug string, inviteCode st
 		if apiErr := parseAPIError(resp, body); apiErr != nil {
 			return "", apiErr
 		}
+
 		return "", fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -392,6 +396,7 @@ func (c *Client) getOrCreatePool(spriteName string) *controlPool {
 
 	pool = newControlPool(c, spriteName)
 	c.pools[spriteName] = pool
+
 	return pool
 }
 

--- a/control_pool.go
+++ b/control_pool.go
@@ -89,6 +89,7 @@ func (p *controlPool) checkout(ctx context.Context) (*controlConn, error) {
 				p.conns = append(p.conns[:i], p.conns[i+1:]...)
 				dbg("sprites: removed closed control conn", "sprite", p.spriteName, "pool", len(p.conns))
 				i--
+
 				continue
 			default:
 			}
@@ -97,6 +98,7 @@ func (p *controlPool) checkout(ctx context.Context) (*controlConn, error) {
 			conn.mu.Unlock()
 			dbg("sprites: checkout control conn", "sprite", p.spriteName, "pool", len(p.conns))
 			p.mu.Unlock()
+
 			return conn, nil
 		}
 		conn.mu.Unlock()
@@ -134,6 +136,7 @@ func (p *controlPool) checkout(ctx context.Context) (*controlConn, error) {
 	p.conns = append(p.conns, conn)
 	dbg("sprites: dialed new control conn", "sprite", p.spriteName, "pool", len(p.conns))
 	p.mu.Unlock()
+
 	return conn, nil
 }
 
@@ -245,6 +248,7 @@ func (p *controlPool) dial(ctx context.Context) (*controlConn, error) {
 			_ = resp.Body.Close()
 			return nil, fmt.Errorf("failed to dial control connection: %v (HTTP %d: %s)", err, resp.StatusCode, string(body))
 		}
+
 		return nil, fmt.Errorf("failed to dial control connection: %v", err)
 	}
 

--- a/errors.go
+++ b/errors.go
@@ -65,6 +65,7 @@ func (e *APIError) Error() string {
 	if e.ErrorCode != "" {
 		return e.ErrorCode
 	}
+
 	return fmt.Sprintf("API error (status %d)", e.StatusCode)
 }
 
@@ -89,6 +90,7 @@ func (e *APIError) GetRetryAfterSeconds() int {
 	if e.RetryAfterSeconds > 0 {
 		return e.RetryAfterSeconds
 	}
+
 	return e.RetryAfterHeader
 }
 
@@ -147,6 +149,7 @@ func IsAPIError(err error) *APIError {
 	if apiErr, ok := err.(*APIError); ok {
 		return apiErr
 	}
+
 	return nil
 }
 
@@ -156,6 +159,7 @@ func IsRateLimitErr(err error) *APIError {
 	if apiErr := IsAPIError(err); apiErr != nil && apiErr.IsRateLimitError() {
 		return apiErr
 	}
+
 	return nil
 }
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,13 +1,15 @@
 module github.com/superfly/sprites-go/examples
 
-go 1.24
+go 1.25.8
 
 require github.com/superfly/sprites-go v0.0.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
-	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/superfly/client-signals v0.2.1 // indirect
+	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/term v0.0.0-20220526004731-065cf7ba2467 // indirect
 )
 

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -2,7 +2,11 @@ github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/superfly/client-signals v0.2.1 h1:4rYN455gl4uhfgeuGwXta0f6U+L7QjZvVNUcVZcW/t8=
+github.com/superfly/client-signals v0.2.1/go.mod h1:YeQnlJ3sh9ptDyq1QZMKYv+AUW9Xuh77lRS9ULj+m2I=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20220526004731-065cf7ba2467 h1:CBpWXWQpIRjzmkkA+M7q9Fqnwd2mZr3AFqexg8YTfoM=
 golang.org/x/term v0.0.0-20220526004731-065cf7ba2467/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/exec.go
+++ b/exec.go
@@ -125,6 +125,7 @@ func (s *Sprite) Command(name string, arg ...string) *Cmd {
 		ctx:    context.Background(),
 		sprite: s,
 	}
+
 	return cmd
 }
 
@@ -137,6 +138,7 @@ func (s *Sprite) CommandContext(ctx context.Context, name string, arg ...string)
 	}
 	cmd := s.Command(name, arg...)
 	cmd.ctx = ctx
+
 	return cmd
 }
 
@@ -146,6 +148,7 @@ func (c *Cmd) String() string {
 	if c == nil {
 		return "<nil>"
 	}
+
 	return fmt.Sprintf("%s %v", c.Path, c.Args[1:])
 }
 
@@ -161,6 +164,7 @@ func (c *Cmd) ConnectionMode() string {
 	if c.controlMode {
 		return "control"
 	}
+
 	return "direct"
 }
 
@@ -169,6 +173,7 @@ func (c *Cmd) Run() error {
 	if err := c.Start(); err != nil {
 		return err
 	}
+
 	return c.Wait()
 }
 
@@ -225,6 +230,7 @@ func (c *Cmd) Start() error {
 			pool.checkin(controlConn)
 		}
 		closeDescriptors(c.closers)
+
 		return err
 	}
 
@@ -236,6 +242,7 @@ func (c *Cmd) Start() error {
 			pool.checkin(controlConn)
 		}
 		closeDescriptors(c.closers)
+
 		return err
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.sprite.client.token))
@@ -316,6 +323,7 @@ func (c *Cmd) Start() error {
 				closeDescriptors(c.closers)
 				return fmt.Errorf("failed to start sprite command: %w", retryErr)
 			}
+
 			return nil
 		}
 
@@ -324,6 +332,7 @@ func (c *Cmd) Start() error {
 			pool.checkin(controlConn)
 		}
 		closeDescriptors(c.closers)
+
 		return fmt.Errorf("failed to start sprite command: %w", err)
 	}
 
@@ -417,6 +426,7 @@ func (c *Cmd) Output() ([]byte, error) {
 	c.Stdout = &outputBuffer{bytes: &stdout}
 
 	err := c.Run()
+
 	return stdout, err
 }
 
@@ -435,6 +445,7 @@ func (c *Cmd) CombinedOutput() ([]byte, error) {
 	c.Stderr = out
 
 	err := c.Run()
+
 	return b, err
 }
 
@@ -452,6 +463,7 @@ func (c *Cmd) StdinPipe() (io.WriteCloser, error) {
 	wp := &writePipe{WriteCloser: pw}
 	c.stdinPipe = wp
 	c.closers = append(c.closers, pr)
+
 	return wp, nil
 }
 
@@ -469,6 +481,7 @@ func (c *Cmd) StdoutPipe() (io.ReadCloser, error) {
 	rp := &readPipe{ReadCloser: pr}
 	c.stdoutPipe = rp
 	c.closers = append(c.closers, pw)
+
 	return rp, nil
 }
 
@@ -486,6 +499,7 @@ func (c *Cmd) StderrPipe() (io.ReadCloser, error) {
 	rp := &readPipe{ReadCloser: pr}
 	c.stderrPipe = rp
 	c.closers = append(c.closers, pw)
+
 	return rp, nil
 }
 
@@ -517,11 +531,13 @@ func (c *Cmd) SetTTYSize(rows, cols uint16) error {
 		if c.wsCmd == nil {
 			return errors.New("sprite: command not fully initialized")
 		}
+
 		return c.wsCmd.Resize(cols, rows)
 	}
 
 	// Otherwise set the initial size
 	c.ttySize = &ttySize{Rows: rows, Cols: cols}
+
 	return nil
 }
 
@@ -577,6 +593,7 @@ func (c *Cmd) Signal(signal string) error {
 	if sessID == "" {
 		return errors.New("sprite: no session ID for HTTP signal fallback")
 	}
+
 	return c.sprite.client.signalSession(c.ctx, c.sprite.name, sessID, signal)
 }
 
@@ -589,6 +606,7 @@ func (c *Cmd) ExitCode() int {
 	if !c.finished {
 		return -1
 	}
+
 	return c.exitCode
 }
 
@@ -667,6 +685,7 @@ func (c *Cmd) buildWebSocketURL() (*url.URL, error) {
 	}
 
 	u.RawQuery = q.Encode()
+
 	return u, nil
 }
 
@@ -722,6 +741,7 @@ func (p *writePipe) Close() error {
 		p.closed = true
 		return p.WriteCloser.Close()
 	}
+
 	return nil
 }
 
@@ -739,6 +759,7 @@ func (p *readPipe) Close() error {
 		p.closed = true
 		return p.ReadCloser.Close()
 	}
+
 	return nil
 }
 
@@ -752,5 +773,6 @@ func (b *outputBuffer) Write(p []byte) (n int, err error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	*b.bytes = append(*b.bytes, p...)
+
 	return len(p), nil
 }

--- a/exec_options.go
+++ b/exec_options.go
@@ -18,5 +18,6 @@ func (c *Cmd) SetControlMode(enable bool) error {
 	}
 
 	c.controlMode = enable
+
 	return nil
 }

--- a/filesystem.go
+++ b/filesystem.go
@@ -87,19 +87,6 @@ type fsListResponse struct {
 	Count   int       `json:"count"`
 }
 
-// fsWriteResponse is the response from /fs/write
-type fsWriteResponse struct {
-	Path string `json:"path"`
-	Size int64  `json:"size"`
-	Mode string `json:"mode"`
-}
-
-// fsDeleteResponse is the response from /fs/delete
-type fsDeleteResponse struct {
-	Deleted []string `json:"deleted"`
-	Count   int      `json:"count"`
-}
-
 // fsRenameRequest is the request body for /fs/rename
 type fsRenameRequest struct {
 	Source     string `json:"source"`
@@ -188,6 +175,7 @@ func (f *spriteFS) statContext(ctx context.Context, name string) (fs.FileInfo, e
 		if json.NewDecoder(resp.Body).Decode(&fsErr) == nil && fsErr.Error != "" {
 			return nil, &fs.PathError{Op: "stat", Path: name, Err: fmt.Errorf("%s", fsErr.Error)}
 		}
+
 		return nil, &fs.PathError{Op: "stat", Path: name, Err: fmt.Errorf("HTTP %d", resp.StatusCode)}
 	}
 
@@ -201,6 +189,7 @@ func (f *spriteFS) statContext(ctx context.Context, name string) (fs.FileInfo, e
 	}
 
 	entry := listResp.Entries[0]
+
 	return &spriteFileInfo{
 		name:    path.Base(entry.Name),
 		size:    entry.Size,
@@ -243,6 +232,7 @@ func (f *spriteFS) ReadFileContext(ctx context.Context, name string) ([]byte, er
 		if json.NewDecoder(resp.Body).Decode(&fsErr) == nil && fsErr.Error != "" {
 			return nil, &fs.PathError{Op: "read", Path: name, Err: fmt.Errorf("%s", fsErr.Error)}
 		}
+
 		return nil, &fs.PathError{Op: "read", Path: name, Err: fmt.Errorf("HTTP %d", resp.StatusCode)}
 	}
 
@@ -281,6 +271,7 @@ func (f *spriteFS) readDirContext(ctx context.Context, name string) ([]fs.DirEnt
 		if json.NewDecoder(resp.Body).Decode(&fsErr) == nil && fsErr.Error != "" {
 			return nil, &fs.PathError{Op: "readdir", Path: name, Err: fmt.Errorf("%s", fsErr.Error)}
 		}
+
 		return nil, &fs.PathError{Op: "readdir", Path: name, Err: fmt.Errorf("HTTP %d", resp.StatusCode)}
 	}
 
@@ -304,6 +295,7 @@ func (f *spriteFS) readDirContext(ctx context.Context, name string) ([]fs.DirEnt
 			},
 		}
 	}
+
 	return entries, nil
 }
 
@@ -340,6 +332,7 @@ func (f *spriteFS) WriteFileContext(ctx context.Context, name string, data []byt
 		if json.NewDecoder(resp.Body).Decode(&fsErr) == nil && fsErr.Error != "" {
 			return &fs.PathError{Op: "write", Path: name, Err: fmt.Errorf("%s", fsErr.Error)}
 		}
+
 		return &fs.PathError{Op: "write", Path: name, Err: fmt.Errorf("HTTP %d", resp.StatusCode)}
 	}
 
@@ -408,6 +401,7 @@ func (f *spriteFS) removeInternal(ctx context.Context, name string, recursive bo
 		if json.NewDecoder(resp.Body).Decode(&fsErr) == nil && fsErr.Error != "" {
 			return &fs.PathError{Op: "remove", Path: name, Err: fmt.Errorf("%s", fsErr.Error)}
 		}
+
 		return &fs.PathError{Op: "remove", Path: name, Err: fmt.Errorf("HTTP %d", resp.StatusCode)}
 	}
 
@@ -452,6 +446,7 @@ func (f *spriteFS) renameContext(ctx context.Context, oldname, newname string) e
 		if json.NewDecoder(resp.Body).Decode(&fsErr) == nil && fsErr.Error != "" {
 			return &fs.PathError{Op: "rename", Path: oldname, Err: fmt.Errorf("%s", fsErr.Error)}
 		}
+
 		return &fs.PathError{Op: "rename", Path: oldname, Err: fmt.Errorf("HTTP %d", resp.StatusCode)}
 	}
 
@@ -498,6 +493,7 @@ func (f *spriteFS) CopyContext(ctx context.Context, src, dst string) error {
 		if json.NewDecoder(resp.Body).Decode(&fsErr) == nil && fsErr.Error != "" {
 			return &fs.PathError{Op: "copy", Path: src, Err: fmt.Errorf("%s", fsErr.Error)}
 		}
+
 		return &fs.PathError{Op: "copy", Path: src, Err: fmt.Errorf("HTTP %d", resp.StatusCode)}
 	}
 
@@ -516,7 +512,7 @@ func (f *spriteFS) ChmodContext(ctx context.Context, name string, mode fs.FileMo
 	body, err := json.Marshal(fsChmodRequest{
 		Path:       name,
 		WorkingDir: f.workingDir,
-		Mode:       fmt.Sprintf("%04o", mode&0777),
+		Mode:       fmt.Sprintf("%04o", mode&0o777),
 	})
 	if err != nil {
 		return &fs.PathError{Op: "chmod", Path: name, Err: err}
@@ -543,6 +539,7 @@ func (f *spriteFS) ChmodContext(ctx context.Context, name string, mode fs.FileMo
 		if json.NewDecoder(resp.Body).Decode(&fsErr) == nil && fsErr.Error != "" {
 			return &fs.PathError{Op: "chmod", Path: name, Err: fmt.Errorf("%s", fsErr.Error)}
 		}
+
 		return &fs.PathError{Op: "chmod", Path: name, Err: fmt.Errorf("HTTP %d", resp.StatusCode)}
 	}
 
@@ -566,14 +563,16 @@ func parseMode(mode string, isDir bool) fs.FileMode {
 	m, err := strconv.ParseUint(mode, 8, 32)
 	if err != nil {
 		if isDir {
-			return fs.ModeDir | 0755
+			return fs.ModeDir | 0o755
 		}
-		return 0644
+
+		return 0o644
 	}
 	fm := fs.FileMode(m)
 	if isDir {
 		fm |= fs.ModeDir
 	}
+
 	return fm
 }
 
@@ -627,8 +626,10 @@ type spriteDir struct {
 }
 
 func (d *spriteDir) Stat() (fs.FileInfo, error) { return d.info, nil }
-func (d *spriteDir) Read(b []byte) (int, error) { return 0, &fs.PathError{Op: "read", Path: d.name, Err: fs.ErrInvalid} }
-func (d *spriteDir) Close() error               { return nil }
+func (d *spriteDir) Read(b []byte) (int, error) {
+	return 0, &fs.PathError{Op: "read", Path: d.name, Err: fs.ErrInvalid}
+}
+func (d *spriteDir) Close() error { return nil }
 
 // ReadDir implements fs.ReadDirFile
 func (d *spriteDir) ReadDir(n int) ([]fs.DirEntry, error) {
@@ -656,5 +657,6 @@ func (d *spriteDir) ReadDir(n int) ([]fs.DirEntry, error) {
 	}
 	entries := d.entries[d.offset:end]
 	d.offset = end
+
 	return entries, nil
 }

--- a/filesystem_control.go
+++ b/filesystem_control.go
@@ -255,7 +255,7 @@ func (s *Sprite) FsReadControl(ctx context.Context, filePath string, opts ...FsC
 func (s *Sprite) FsWriteControl(ctx context.Context, filePath string, data []byte, opts ...FsControlOption) (*FsWriteResult, error) {
 	o := &fsControlOpts{
 		workingDir:   "/home/sprite",
-		mode:         0644,
+		mode:         0o644,
 		mkdirParents: true,
 	}
 	for _, opt := range opts {
@@ -701,6 +701,7 @@ func (s *Sprite) checkoutControlConn(ctx context.Context) (*controlConn, error) 
 	}
 
 	pool := s.client.getOrCreatePool(s.name)
+
 	return pool.checkout(ctx)
 }
 
@@ -752,6 +753,7 @@ func (s *Sprite) waitControlComplete(conn *controlConn) error {
 			if json.Unmarshal(msg.Args, &errArgs) == nil {
 				return fmt.Errorf("operation failed: %s", errArgs.Error)
 			}
+
 			return fmt.Errorf("operation failed")
 		}
 	}

--- a/management.go
+++ b/management.go
@@ -60,6 +60,7 @@ func (c *Client) CreateSpriteWithOrg(ctx context.Context, name string, config *S
 		if apiErr := parseAPIError(resp, body); apiErr != nil {
 			return nil, apiErr
 		}
+
 		return nil, fmt.Errorf("failed to create sprite (status %d): %s", resp.StatusCode, string(body))
 	}
 
@@ -115,6 +116,7 @@ func (c *Client) GetSpriteWithOrg(ctx context.Context, name string, org *Organiz
 		if apiErr := parseAPIError(resp, body); apiErr != nil {
 			return nil, apiErr
 		}
+
 		return nil, fmt.Errorf("failed to get sprite (status %d): %s", resp.StatusCode, string(body))
 	}
 
@@ -144,6 +146,7 @@ func (c *Client) GetSpriteWithOrg(ctx context.Context, name string, org *Organiz
 		LastRunningAt:    info.LastRunningAt,
 		LastWarmingAt:    info.LastWarmingAt,
 	}
+
 	return sprite, nil
 }
 
@@ -196,6 +199,7 @@ func (c *Client) ListSprites(ctx context.Context, opts *ListOptions) (*SpriteLis
 		if apiErr := parseAPIError(resp, body); apiErr != nil {
 			return nil, apiErr
 		}
+
 		return nil, fmt.Errorf("failed to list sprites (status %d): %s", resp.StatusCode, string(body))
 	}
 
@@ -228,6 +232,7 @@ func (c *Client) ListAllSpritesWithOrg(ctx context.Context, prefix string, org *
 	if err != nil {
 		return nil, err
 	}
+
 	return result.Sprites, nil
 }
 
@@ -313,6 +318,7 @@ func (c *Client) DeleteSprite(ctx context.Context, name string) error {
 		if apiErr := parseAPIError(resp, body); apiErr != nil {
 			return apiErr
 		}
+
 		return fmt.Errorf("failed to delete sprite (status %d): %s", resp.StatusCode, string(body))
 	}
 
@@ -356,6 +362,7 @@ func (c *Client) UpgradeSprite(ctx context.Context, name string) error {
 		if apiErr := parseAPIError(resp, body); apiErr != nil {
 			return apiErr
 		}
+
 		return fmt.Errorf("failed to upgrade sprite (status %d): %s", resp.StatusCode, string(body))
 	}
 
@@ -404,6 +411,7 @@ func (c *Client) UpdateURLSettings(ctx context.Context, spriteName string, setti
 		if apiErr := parseAPIError(resp, body); apiErr != nil {
 			return apiErr
 		}
+
 		return fmt.Errorf("failed to update URL settings (status %d): %s", resp.StatusCode, string(body))
 	}
 
@@ -443,6 +451,7 @@ func (c *Client) UpdateSprite(ctx context.Context, spriteName string, req *Updat
 		if apiErr := parseAPIError(resp, body); apiErr != nil {
 			return apiErr
 		}
+
 		return fmt.Errorf("failed to update sprite (status %d): %s", resp.StatusCode, string(body))
 	}
 

--- a/proxy.go
+++ b/proxy.go
@@ -60,6 +60,7 @@ func (conn *proxyConn) Read(p []byte) (n int, err error) {
 				conn.readReader = nil
 				continue
 			}
+
 			return n, err
 		}
 
@@ -68,6 +69,7 @@ func (conn *proxyConn) Read(p []byte) (n int, err error) {
 			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
 				return 0, io.EOF
 			}
+
 			return 0, err
 		}
 		// only handle binary messages
@@ -104,6 +106,7 @@ func (conn *proxyConn) Close() error {
 		)
 		closeErr = conn.conn.Close()
 	})
+
 	return closeErr
 }
 
@@ -111,6 +114,7 @@ func (conn *proxyConn) LocalAddr() net.Addr {
 	// there is no local address, return nil
 	return nil
 }
+
 func (conn *proxyConn) RemoteAddr() net.Addr {
 	return conn.remoteAddr
 }
@@ -119,11 +123,14 @@ func (conn *proxyConn) SetDeadline(t time.Time) error {
 	if err := conn.SetReadDeadline(t); err != nil {
 		return err
 	}
+
 	return conn.SetWriteDeadline(t)
 }
+
 func (conn *proxyConn) SetReadDeadline(t time.Time) error {
 	return conn.conn.SetReadDeadline(t)
 }
+
 func (conn *proxyConn) SetWriteDeadline(t time.Time) error {
 	return conn.conn.SetWriteDeadline(t)
 }
@@ -144,6 +151,7 @@ func (c *controlProxyConn) Close() error {
 		c.control.sendRelease()
 		c.pool.checkin(c.control)
 	})
+
 	return nil
 }
 
@@ -157,6 +165,7 @@ func (c *Client) ProxySocket(ctx context.Context, network, spriteName, addr stri
 		if err != nil {
 			return nil, err
 		}
+
 		return initSocketTCP(ctx, wsConn, addr)
 	default:
 		return nil, fmt.Errorf("unsupported network type %q", network)
@@ -194,15 +203,12 @@ func wsProxyHandshake(
 	// Race with ctx.Done in a goroutine
 	go func() {
 		var err error
-		if err := wsConn.WriteJSON(initMsg); err != nil {
-			err = fmt.Errorf("failed to send init message: %w", err)
-		} else {
-			// Read response
-			if err := wsConn.ReadJSON(&response); err != nil {
-				err = fmt.Errorf("failed to read response: %w", err)
-			} else if response.Status != "connected" {
-				err = fmt.Errorf("unexpected status: %s", response.Status)
-			}
+		if writeErr := wsConn.WriteJSON(initMsg); writeErr != nil {
+			err = fmt.Errorf("failed to send init message: %w", writeErr)
+		} else if readErr := wsConn.ReadJSON(&response); readErr != nil {
+			err = fmt.Errorf("failed to read response: %w", readErr)
+		} else if response.Status != "connected" {
+			err = fmt.Errorf("unexpected status: %s", response.Status)
 		}
 		errChan <- err
 	}()
@@ -235,8 +241,9 @@ func initSocketTCP(ctx context.Context, wsConn *websocket.Conn, addr string) (ne
 
 	initMsg := &ProxyInitMessage{
 		Host: host,
-		Port: int(port),
+		Port: port,
 	}
+
 	return wsProxyHandshake(ctx, wsConn, initMsg)
 }
 
@@ -303,7 +310,10 @@ func (c *Client) dialProxyWebSocket(ctx context.Context, spriteName string) (*we
 	applyClientSignalHeaders(header, c.clientSignals)
 
 	// Connect to WebSocket
-	wsConn, _, err := dialer.DialContext(ctx, wsURL.String(), header)
+	wsConn, resp, err := dialer.DialContext(ctx, wsURL.String(), header)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect: %w", err)
 	}
@@ -364,6 +374,7 @@ func (c *Client) ProxyPorts(ctx context.Context, spriteName string, mappings []P
 			for _, s := range sessions {
 				s.Close()
 			}
+
 			return nil, fmt.Errorf("failed to create proxy for port %d: %w", mapping.LocalPort, err)
 		}
 		sessions = append(sessions, session)
@@ -402,6 +413,7 @@ func (c *Client) createProxySession(ctx context.Context, spriteName string, mapp
 			if session.RemoteHost != "" {
 				return session.RemoteHost
 			}
+
 			return "localhost"
 		}(),
 		"remote_port", session.RemotePort,
@@ -486,6 +498,7 @@ func (ps *ProxySession) handleConnection(localConn net.Conn) {
 				)
 				controlConn.sendRelease()
 				pool.checkin(controlConn)
+
 				return
 			}
 		}
@@ -499,6 +512,7 @@ func (ps *ProxySession) handleConnection(localConn net.Conn) {
 				"sprite", ps.spriteName,
 				"error", dialErr,
 			)
+
 			return
 		}
 
@@ -509,6 +523,7 @@ func (ps *ProxySession) handleConnection(localConn net.Conn) {
 				"error", err,
 			)
 			wsConn.Close()
+
 			return
 		}
 	}
@@ -583,6 +598,7 @@ func (ps *ProxySession) LocalAddr() net.Addr {
 	if ps.listener != nil {
 		return ps.listener.Addr()
 	}
+
 	return nil
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -311,10 +311,16 @@ func (c *Client) dialProxyWebSocket(ctx context.Context, spriteName string) (*we
 
 	// Connect to WebSocket
 	wsConn, resp, err := dialer.DialContext(ctx, wsURL.String(), header)
-	if resp != nil {
-		defer resp.Body.Close()
-	}
 	if err != nil {
+		// On success, resp.Body must be left alone: gorilla/websocket hands
+		// back the *http.Response tied to the now-live connection, and
+		// closing its body here would close the WebSocket too. Only close
+		// it in the error path, where resp (if non-nil) is just a
+		// diagnostic response body, not the live connection.
+		if resp != nil {
+			resp.Body.Close()
+		}
+
 		return nil, fmt.Errorf("failed to connect: %w", err)
 	}
 

--- a/services.go
+++ b/services.go
@@ -29,6 +29,7 @@ func (ss *ServiceStream) Next() (*ServiceLogEvent, error) {
 		if err := ss.scanner.Err(); err != nil {
 			return nil, err
 		}
+
 		return nil, io.EOF
 	}
 
@@ -51,6 +52,7 @@ func (ss *ServiceStream) Close() error {
 	if ss.reader != nil {
 		return ss.reader.Close()
 	}
+
 	return nil
 }
 

--- a/session.go
+++ b/session.go
@@ -164,5 +164,6 @@ func (s *Session) GetActivityAge() time.Duration {
 	if s.LastActivity == nil {
 		return time.Since(s.Created)
 	}
+
 	return time.Since(*s.LastActivity)
 }

--- a/test-cli/go.mod
+++ b/test-cli/go.mod
@@ -1,15 +1,15 @@
 module github.com/superfly/sprites-go/test-cli
 
-go 1.24
-
-toolchain go1.24.4
+go 1.25.8
 
 require github.com/superfly/sprites-go v0.0.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
-	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/superfly/client-signals v0.2.1 // indirect
+	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/term v0.0.0-20220526004731-065cf7ba2467 // indirect
 )
 

--- a/test-cli/go.sum
+++ b/test-cli/go.sum
@@ -2,7 +2,11 @@ github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/superfly/client-signals v0.2.1 h1:4rYN455gl4uhfgeuGwXta0f6U+L7QjZvVNUcVZcW/t8=
+github.com/superfly/client-signals v0.2.1/go.mod h1:YeQnlJ3sh9ptDyq1QZMKYv+AUW9Xuh77lRS9ULj+m2I=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20220526004731-065cf7ba2467 h1:CBpWXWQpIRjzmkkA+M7q9Fqnwd2mZr3AFqexg8YTfoM=
 golang.org/x/term v0.0.0-20220526004731-065cf7ba2467/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/test-cli/main.go
+++ b/test-cli/main.go
@@ -31,7 +31,7 @@ func NewLogger(logPath string) (*Logger, error) {
 		return &Logger{}, nil
 	}
 
-	file, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	file, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open log file: %w", err)
 	}
@@ -743,7 +743,7 @@ func handleFsWrite(token, baseURL, spriteName, workingDir, path, content string,
 		fsys = sprite.Filesystem()
 	}
 
-	err := fsys.WriteFile(path, []byte(content), 0644)
+	err := fsys.WriteFile(path, []byte(content), 0o644)
 	if err != nil {
 		logger.LogEvent("fs_write_failed", map[string]interface{}{
 			"error": err.Error(),
@@ -902,9 +902,9 @@ func handleFsMkdir(token, baseURL, spriteName, workingDir, path string, parents 
 
 	var err error
 	if parents {
-		err = fsys.MkdirAll(path, 0755)
+		err = fsys.MkdirAll(path, 0o755)
 	} else {
-		err = fsys.Mkdir(path, 0755)
+		err = fsys.Mkdir(path, 0o755)
 	}
 	if err != nil {
 		logger.LogEvent("fs_mkdir_failed", map[string]interface{}{

--- a/version.go
+++ b/version.go
@@ -34,6 +34,7 @@ func extractChannel(version string) string {
 		if strings.HasPrefix(suffix, "rc") {
 			return "rc"
 		}
+
 		return suffix
 	}
 
@@ -72,7 +73,7 @@ func supportsPathAttach(version string) bool {
 
 // versionCapturingTransport wraps an http.RoundTripper to capture Sprite-Version headers.
 type versionCapturingTransport struct {
-	wrapped   http.RoundTripper
+	wrapped       http.RoundTripper
 	versionHolder *atomic.Value
 }
 

--- a/websocket.go
+++ b/websocket.go
@@ -107,6 +107,7 @@ func newWSCmd(req *http.Request, name string, arg ...string) *wsCmd {
 	if req == nil {
 		panic("sprites: newWSCmd called with nil request")
 	}
+
 	return &wsCmd{
 		Path:      name,
 		Args:      append([]string{name}, arg...),
@@ -125,6 +126,7 @@ func newWSCmdContext(ctx context.Context, req *http.Request, name string, arg ..
 	}
 	c := newWSCmd(req, name, arg...)
 	c.ctx = ctx
+
 	return c
 }
 
@@ -133,6 +135,7 @@ func (c *wsCmd) Run() error {
 	if err := c.Start(); err != nil {
 		return err
 	}
+
 	return c.Wait()
 }
 
@@ -196,7 +199,11 @@ func (c *wsCmd) start() {
 				"op":   "exec",
 				"args": args,
 			}
-			b, _ := json.Marshal(env)
+			b, err := json.Marshal(env)
+			if err != nil {
+				c.startChan <- fmt.Errorf("failed to marshal operation start message: %w", err)
+				return
+			}
 			payload := append([]byte("control:"), b...)
 			dbg("sprites: sending control op.start", "args_len", len(b))
 			if err := conn.WriteMessage(websocket.TextMessage, payload); err != nil {
@@ -237,6 +244,7 @@ func (c *wsCmd) start() {
 				errMsg = fmt.Sprintf("failed to connect: %v (HTTP %d)", err, resp.StatusCode)
 			}
 			c.startChan <- fmt.Errorf("%s", errMsg)
+
 			return
 		}
 	}
@@ -351,6 +359,7 @@ func (c *wsCmd) waitForSessionInfo() error {
 				if c.TextMessageHandler != nil {
 					c.TextMessageHandler(data)
 				}
+
 				return nil
 			}
 			// Pass other text messages to handler
@@ -467,6 +476,7 @@ func (c *wsCmd) runIO() {
 					case c.exitChan <- 1:
 					default:
 					}
+
 					return
 				}
 				if closeErr, ok := err.(*websocket.CloseError); ok && closeErr.Code == websocket.CloseNormalClosure {
@@ -480,6 +490,7 @@ func (c *wsCmd) runIO() {
 					default:
 					}
 				}
+
 				return
 			}
 			// Reset read deadline on any successful read
@@ -518,6 +529,7 @@ func (c *wsCmd) runIO() {
 						default:
 						}
 						adapter.Close()
+
 						return
 					}
 				} else {
@@ -548,7 +560,7 @@ func (c *wsCmd) runIO() {
 				adapter.WriteStream(StreamStdinEOF, []byte{})
 			}
 		}()
-	} else if !(c.usingControl && c.controlConn != nil) {
+	} else if !c.usingControl || c.controlConn == nil {
 		// For legacy direct connections, send EOF immediately if no stdin is provided
 		go func() {
 			adapter.WriteStream(StreamStdinEOF, []byte{})
@@ -595,6 +607,7 @@ func (c *wsCmd) runIO() {
 					default:
 					}
 					adapter.Close()
+
 					return
 				}
 			} else {
@@ -626,6 +639,7 @@ func (c *wsCmd) runIO() {
 					}
 				}
 				adapter.Close()
+
 				return
 			}
 		}
@@ -643,6 +657,7 @@ func (c *wsCmd) ExitCode() int {
 		case c.exitChan <- code:
 		default:
 		}
+
 		return code
 	default:
 		// receivedExit is true but exitChan is empty - exit code was 0
@@ -670,6 +685,7 @@ func (c *wsCmd) Close() error {
 			deadline)
 		c.conn.Close()
 	}
+
 	return nil
 }
 
@@ -679,6 +695,7 @@ func (c *wsCmd) Resize(width, height uint16) error {
 		return nil
 	}
 	msg := &ControlMessage{Type: "resize", Cols: width, Rows: height}
+
 	return c.adapter.WriteControl(msg)
 }
 
@@ -688,6 +705,7 @@ func (c *wsCmd) Signal(signal string) error {
 		return errors.New("websocket not connected")
 	}
 	msg := &ControlMessage{Type: "signal", Signal: signal}
+
 	return c.adapter.WriteControl(msg)
 }
 
@@ -696,6 +714,7 @@ func (c *wsCmd) HasCapability(cap string) bool {
 	if c.capabilities == nil {
 		return false
 	}
+
 	return c.capabilities[cap]
 }
 
@@ -713,6 +732,7 @@ func newWSAdapter(conn *websocket.Conn, isPTY bool) *wsAdapter {
 		done:      make(chan struct{}),
 	}
 	go a.writeLoop()
+
 	return a
 }
 
@@ -788,6 +808,7 @@ func (a *wsAdapter) WriteStream(stream StreamID, data []byte) error {
 	msg := make([]byte, len(data)+1)
 	msg[0] = byte(stream)
 	copy(msg[1:], data)
+
 	return a.WriteRaw(msg)
 }
 
@@ -800,6 +821,7 @@ func (a *wsAdapter) Write(p []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+
 	return len(p), nil
 }
 
@@ -820,6 +842,7 @@ func (w *streamWriter) Write(p []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+
 	return len(p), nil
 }
 
@@ -832,5 +855,6 @@ func (w *rawWriter) Write(p []byte) (int, error) {
 	if err := w.ws.WriteRaw(p); err != nil {
 		return 0, err
 	}
+
 	return len(p), nil
 }


### PR DESCRIPTION
This repo currently has no lint/test CI at all beyond the release workflow added separately. Ports the same setup fly-go and client-signals use: `.github/workflows/checks.yml` (golangci-lint + `go test` across ubuntu/macos/windows) and `.golangci.yml`, adapted to this repo's actual dependencies (`gomodguard` allowlist matches `go.mod`; `gofumpt` module-path set to `github.com/superfly/sprites-go`).

`examples/` is its own nested Go module (separate `go.mod`), so it's naturally out of scope for `go test ./...`/`go build ./...` here, matching the `examples$` lint exclusion already in the config.

## Fixing the existing code

Introducing lint cold surfaced real pre-existing issues, fixed here so CI starts green rather than red:

- **proxy.go**: `dialProxyWebSocket` discarded the `*http.Response` from `dialer.DialContext` without closing its body (`bodyclose`).
- **proxy.go**: `wsProxyHandshake`'s goroutine re-declared `err` via `:=` inside both the outer and inner `if` statements, shadowing the outer `err` that actually gets sent on `errChan` — so handshake failures (bad `WriteJSON`, bad `ReadJSON`, a non-`"connected"` status) were silently swallowed as `nil` instead of surfacing as errors. Renamed the inner ones to `writeErr`/`readErr` so the outer `err` is the one actually assigned.
- **websocket.go**: an unchecked `json.Marshal` error is now checked and reported on `startChan`, same as the adjacent `WriteMessage` error right below it.
- **filesystem.go**: removed `fsWriteResponse`/`fsDeleteResponse`, two unused types with no references anywhere in the codebase.
- **proxy.go**: dropped a redundant `int(port)` conversion (`port` is already `int`).
- **websocket.go**: simplified a negated `&&` into De Morgan's form per staticcheck.
- Everything else (gofumpt formatting, `ineffassign`, `nlreturn` blank-line-before-return/continue) applied mechanically via `gofumpt -w` and `golangci-lint --fix`.

Verified with `go build ./...`, `go vet ./...`, `go test ./...`, and a clean `golangci-lint run ./...`.