### PR TITLE
Bump github.com/superfly/client-signals to v0.3.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,7 +29,7 @@ linters:
           - github.com/Masterminds/semver/v3
           - github.com/gorilla/websocket
           - github.com/hashicorp/go-cleanhttp
-          - github.com/superfly/client-signals
+          - github.com/superfly/client-signals/go
         domains:
           - golang.org
       blocked:

--- a/client.go
+++ b/client.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
-	clientsignals "github.com/superfly/client-signals"
+	clientsignals "github.com/superfly/client-signals/go"
 )
 
 // Client is the main SDK client for interacting with the sprite API.

--- a/client_signals.go
+++ b/client_signals.go
@@ -3,7 +3,7 @@ package sprites
 import (
 	"net/http"
 
-	clientsignals "github.com/superfly/client-signals"
+	clientsignals "github.com/superfly/client-signals/go"
 )
 
 // WithClientSignals attaches coarse, privacy-safe client-signal headers

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/superfly/client-signals v0.2.1 // indirect
+	github.com/superfly/client-signals/go v0.3.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/term v0.0.0-20220526004731-065cf7ba2467 // indirect
 )

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -4,8 +4,8 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
-github.com/superfly/client-signals v0.2.1 h1:4rYN455gl4uhfgeuGwXta0f6U+L7QjZvVNUcVZcW/t8=
-github.com/superfly/client-signals v0.2.1/go.mod h1:YeQnlJ3sh9ptDyq1QZMKYv+AUW9Xuh77lRS9ULj+m2I=
+github.com/superfly/client-signals/go v0.3.0 h1:UegKdBgPCYn5FqSGdxHUIeyLTAGWnd0kYxlioARw4LY=
+github.com/superfly/client-signals/go v0.3.0/go.mod h1:v/FQ2fZ4zOkOxKmue+bYh96awuh9Qh1ImcdxzRYcHFA=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20220526004731-065cf7ba2467 h1:CBpWXWQpIRjzmkkA+M7q9Fqnwd2mZr3AFqexg8YTfoM=

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
-	github.com/superfly/client-signals v0.2.1
+	github.com/superfly/client-signals/go v0.3.0
 	golang.org/x/term v0.0.0-20220526004731-065cf7ba2467
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
-github.com/superfly/client-signals v0.2.1 h1:4rYN455gl4uhfgeuGwXta0f6U+L7QjZvVNUcVZcW/t8=
-github.com/superfly/client-signals v0.2.1/go.mod h1:YeQnlJ3sh9ptDyq1QZMKYv+AUW9Xuh77lRS9ULj+m2I=
+github.com/superfly/client-signals/go v0.3.0 h1:UegKdBgPCYn5FqSGdxHUIeyLTAGWnd0kYxlioARw4LY=
+github.com/superfly/client-signals/go v0.3.0/go.mod h1:v/FQ2fZ4zOkOxKmue+bYh96awuh9Qh1ImcdxzRYcHFA=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20220526004731-065cf7ba2467 h1:CBpWXWQpIRjzmkkA+M7q9Fqnwd2mZr3AFqexg8YTfoM=

--- a/test-cli/go.mod
+++ b/test-cli/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/superfly/client-signals v0.2.1 // indirect
+	github.com/superfly/client-signals/go v0.3.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/term v0.0.0-20220526004731-065cf7ba2467 // indirect
 )

--- a/test-cli/go.sum
+++ b/test-cli/go.sum
@@ -4,8 +4,8 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
-github.com/superfly/client-signals v0.2.1 h1:4rYN455gl4uhfgeuGwXta0f6U+L7QjZvVNUcVZcW/t8=
-github.com/superfly/client-signals v0.2.1/go.mod h1:YeQnlJ3sh9ptDyq1QZMKYv+AUW9Xuh77lRS9ULj+m2I=
+github.com/superfly/client-signals/go v0.3.0 h1:UegKdBgPCYn5FqSGdxHUIeyLTAGWnd0kYxlioARw4LY=
+github.com/superfly/client-signals/go v0.3.0/go.mod h1:v/FQ2fZ4zOkOxKmue+bYh96awuh9Qh1ImcdxzRYcHFA=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20220526004731-065cf7ba2467 h1:CBpWXWQpIRjzmkkA+M7q9Fqnwd2mZr3AFqexg8YTfoM=


### PR DESCRIPTION
Bumps `github.com/superfly/client-signals` from v0.2.1 to v0.3.0.

## Context

The Go module in `client-signals` moved into a `go/` subdirectory as of v0.3.0, so its import path changes from `github.com/superfly/client-signals` to `github.com/superfly/client-signals/go`. Consuming that version required upstream to backfill a `go/v0.3.0` git tag matching Go's nested-module versioning convention, tracked in [superfly/client-signals#2](https://github.com/superfly/client-signals/issues/2) (now fixed).

## Details

Updated the import path everywhere it's used (`client.go`, `client_signals.go`, and the `test-cli`/`examples` submodules' go.mod files) and the `gomodguard` allowlist in `.golangci.yml` to match the new module path.