### PR TITLE
Frame control-mode stdin consistently

### DIFF
--- a/exec_test.go
+++ b/exec_test.go
@@ -3,11 +3,14 @@ package sprites
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"syscall"
 	"testing"
+	"testing/iotest"
 	"time"
 )
 
@@ -44,6 +47,29 @@ func TestCopyNonTTYStdinUsesStreamFrames(t *testing.T) {
 	}
 	if socket.frames[0].stream != StreamStdin || string(socket.frames[0].data) != "hello\n" {
 		t.Errorf("stdin frame = %#v, want stream %d with payload %q", socket.frames[0], StreamStdin, "hello\n")
+	}
+	if socket.frames[1].stream != StreamStdinEOF || len(socket.frames[1].data) != 0 {
+		t.Errorf("EOF frame = %#v, want empty stream %d frame", socket.frames[1], StreamStdinEOF)
+	}
+}
+
+func TestCopyNonTTYStdinSendsEOFAfterReadError(t *testing.T) {
+	socket := &recordingStreamSocket{}
+	copyErr := errors.New("read failed")
+	stdin := io.MultiReader(strings.NewReader("hello"), iotest.ErrReader(copyErr))
+
+	n, err := copyNonTTYStdin(socket, stdin)
+	if !errors.Is(err, copyErr) {
+		t.Fatalf("copyNonTTYStdin() error = %v, want %v", err, copyErr)
+	}
+	if n != 5 {
+		t.Fatalf("copyNonTTYStdin() copied %d bytes, want 5", n)
+	}
+	if len(socket.frames) != 2 {
+		t.Fatalf("got %d frames, want stdin and EOF frames", len(socket.frames))
+	}
+	if socket.frames[0].stream != StreamStdin || string(socket.frames[0].data) != "hello" {
+		t.Errorf("stdin frame = %#v, want stream %d with payload %q", socket.frames[0], StreamStdin, "hello")
 	}
 	if socket.frames[1].stream != StreamStdinEOF || len(socket.frames[1].data) != 0 {
 		t.Errorf("EOF frame = %#v, want empty stream %d frame", socket.frames[1], StreamStdinEOF)

--- a/exec_test.go
+++ b/exec_test.go
@@ -1,6 +1,7 @@
 package sprites
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -9,6 +10,44 @@ import (
 	"testing"
 	"time"
 )
+
+type recordedStreamFrame struct {
+	stream StreamID
+	data   []byte
+}
+
+type recordingStreamSocket struct {
+	frames []recordedStreamFrame
+}
+
+func (w *recordingStreamSocket) WriteStream(stream StreamID, data []byte) error {
+	w.frames = append(w.frames, recordedStreamFrame{
+		stream: stream,
+		data:   bytes.Clone(data),
+	})
+	return nil
+}
+
+func TestCopyNonTTYStdinUsesStreamFrames(t *testing.T) {
+	socket := &recordingStreamSocket{}
+
+	n, err := copyNonTTYStdin(socket, strings.NewReader("hello\n"))
+	if err != nil {
+		t.Fatalf("copyNonTTYStdin() error = %v", err)
+	}
+	if n != 6 {
+		t.Fatalf("copyNonTTYStdin() copied %d bytes, want 6", n)
+	}
+	if len(socket.frames) != 2 {
+		t.Fatalf("got %d frames, want stdin and EOF frames", len(socket.frames))
+	}
+	if socket.frames[0].stream != StreamStdin || string(socket.frames[0].data) != "hello\n" {
+		t.Errorf("stdin frame = %#v, want stream %d with payload %q", socket.frames[0], StreamStdin, "hello\n")
+	}
+	if socket.frames[1].stream != StreamStdinEOF || len(socket.frames[1].data) != 0 {
+		t.Errorf("EOF frame = %#v, want empty stream %d frame", socket.frames[1], StreamStdinEOF)
+	}
+}
 
 func TestCmdString(t *testing.T) {
 	client := New("test-token", WithBaseURL("http://localhost:8080"))

--- a/exec_test.go
+++ b/exec_test.go
@@ -25,6 +25,7 @@ func (w *recordingStreamSocket) WriteStream(stream StreamID, data []byte) error 
 		stream: stream,
 		data:   bytes.Clone(data),
 	})
+
 	return nil
 }
 

--- a/websocket.go
+++ b/websocket.go
@@ -546,19 +546,12 @@ func (c *wsCmd) runIO() {
 	// Non-PTY mode - handle stream-based I/O
 	if c.Stdin != nil {
 		go func() {
-			if c.usingControl && c.controlConn != nil {
-				// For control connections, send raw bytes and then a single-byte EOF marker (0x04)
-				rw := &rawWriter{ws: adapter}
-				n, _ := io.Copy(rw, c.Stdin)
-				dbg("sprites: sent stdin bytes", "n", n)
-				adapter.WriteRaw([]byte{byte(StreamStdinEOF)})
-				dbg("sprites: sent stdin EOF")
-			} else {
-				stdinWriter := &streamWriter{ws: adapter, streamID: StreamStdin}
-				n, _ := io.Copy(stdinWriter, c.Stdin)
-				dbg("sprites: sent stdin bytes (legacy)", "n", n)
-				adapter.WriteStream(StreamStdinEOF, []byte{})
+			n, err := copyNonTTYStdin(adapter, c.Stdin)
+			if err != nil {
+				dbg("sprites: failed to send stdin", "n", n, "error", err)
+				return
 			}
+			dbg("sprites: sent stdin bytes", "n", n, "control", c.usingControl)
 		}()
 	} else if !c.usingControl || c.controlConn == nil {
 		// For legacy direct connections, send EOF immediately if no stdin is provided
@@ -831,28 +824,31 @@ func (a *wsAdapter) Close() error {
 	return a.conn.Close()
 }
 
+type streamSocket interface {
+	WriteStream(StreamID, []byte) error
+}
+
+func copyNonTTYStdin(ws streamSocket, stdin io.Reader) (int64, error) {
+	stdinWriter := &streamWriter{ws: ws, streamID: StreamStdin}
+	n, err := io.Copy(stdinWriter, stdin)
+	if err != nil {
+		return n, err
+	}
+	if err := ws.WriteStream(StreamStdinEOF, nil); err != nil {
+		return n, err
+	}
+	return n, nil
+}
+
 // streamWriter writes to a specific stream via the adapter
 type streamWriter struct {
-	ws       *wsAdapter
+	ws       streamSocket
 	streamID StreamID
 }
 
 func (w *streamWriter) Write(p []byte) (int, error) {
 	err := w.ws.WriteStream(w.streamID, p)
 	if err != nil {
-		return 0, err
-	}
-
-	return len(p), nil
-}
-
-// rawWriter writes raw bytes without any stream framing
-type rawWriter struct {
-	ws *wsAdapter
-}
-
-func (w *rawWriter) Write(p []byte) (int, error) {
-	if err := w.ws.WriteRaw(p); err != nil {
 		return 0, err
 	}
 

--- a/websocket.go
+++ b/websocket.go
@@ -837,6 +837,7 @@ func copyNonTTYStdin(ws streamSocket, stdin io.Reader) (int64, error) {
 	if err := ws.WriteStream(StreamStdinEOF, nil); err != nil {
 		return n, err
 	}
+
 	return n, nil
 }
 

--- a/websocket.go
+++ b/websocket.go
@@ -830,15 +830,14 @@ type streamSocket interface {
 
 func copyNonTTYStdin(ws streamSocket, stdin io.Reader) (int64, error) {
 	stdinWriter := &streamWriter{ws: ws, streamID: StreamStdin}
-	n, err := io.Copy(stdinWriter, stdin)
-	if err != nil {
-		return n, err
-	}
-	if err := ws.WriteStream(StreamStdinEOF, nil); err != nil {
-		return n, err
+	n, copyErr := io.Copy(stdinWriter, stdin)
+	// A read-side failure should not leave the remote process waiting for stdin.
+	eofErr := ws.WriteStream(StreamStdinEOF, nil)
+	if copyErr != nil {
+		return n, copyErr
 	}
 
-	return n, nil
+	return n, eofErr
 }
 
 // streamWriter writes to a specific stream via the adapter


### PR DESCRIPTION
## Summary

- send non-TTY stdin through the same stream framing in control and direct execution modes
- send stdin EOF as an empty `StreamStdinEOF` frame
- attempt the EOF frame even when copying caller-provided stdin returns an error
- remove the control-only raw writer
- add regression tests for framing and EOF after a mid-stream read error

## User impact

Commands selected for control-channel execution now receive caller-provided stdin instead of silently seeing an empty input stream. Reader failures still signal EOF so the remote process does not remain blocked on stdin.

## Validation

- `go test ./...`
- `go vet ./...`
- Live Sprite control-channel repro (sprite name omitted):
  - `printf "hello\n" | sprite -s <sprite-name> exec --control -- cat`
  - deployed CLI/SDK baseline: no output, reproducing #22
  - same CLI rebuilt with `github.com/superfly/sprites-go` replaced by this PR branch: `hello`

The current CLI uses the hidden `--control` spelling; the older `-control` spelling from the report is no longer accepted by its flag parser.

## Versioning and deployment

This is a backwards-compatible patch fix. Go module releases are tag-based, so this PR does not add an in-source version change; no service deployment is required.

Fixes #22.