### PR TITLE
Preserve exec WebSocket read errors

### DIFF
--- a/exec_test.go
+++ b/exec_test.go
@@ -6,12 +6,16 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"syscall"
 	"testing"
 	"testing/iotest"
 	"time"
+
+	"github.com/gorilla/websocket"
 )
 
 type recordedStreamFrame struct {
@@ -73,6 +77,63 @@ func TestCopyNonTTYStdinSendsEOFAfterReadError(t *testing.T) {
 	}
 	if socket.frames[1].stream != StreamStdinEOF || len(socket.frames[1].data) != 0 {
 		t.Errorf("EOF frame = %#v, want empty stream %d frame", socket.frames[1], StreamStdinEOF)
+	}
+}
+
+func TestCmdWaitPreservesWebSocketReadError(t *testing.T) {
+	const closeReason = "transport interrupted"
+
+	serverErr := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := (&websocket.Upgrader{}).Upgrade(w, r, nil)
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		defer conn.Close()
+
+		serverErr <- conn.WriteControl(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseInternalServerErr, closeReason),
+			time.Now().Add(time.Second),
+		)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "ws"+strings.TrimPrefix(server.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext() error = %v", err)
+	}
+
+	stdinReader, stdinWriter := io.Pipe()
+	defer stdinReader.Close()
+	defer stdinWriter.Close()
+
+	wsCmd := newWSCmdContext(ctx, req, "true")
+	wsCmd.Stdin = stdinReader
+	if err := wsCmd.Start(); err != nil {
+		t.Fatalf("wsCmd.Start() error = %v", err)
+	}
+
+	cmd := &Cmd{started: true, wsCmd: wsCmd}
+	err = cmd.Wait()
+	_ = stdinWriter.Close()
+
+	var closeErr *websocket.CloseError
+	if !errors.As(err, &closeErr) {
+		t.Fatalf("Cmd.Wait() error = %v (%T), want *websocket.CloseError", err, err)
+	}
+	if closeErr.Code != websocket.CloseInternalServerErr {
+		t.Errorf("close code = %d, want %d", closeErr.Code, websocket.CloseInternalServerErr)
+	}
+	if closeErr.Text != closeReason {
+		t.Errorf("close reason = %q, want %q", closeErr.Text, closeReason)
+	}
+	if err := <-serverErr; err != nil {
+		t.Fatalf("server close error = %v", err)
 	}
 }
 

--- a/websocket.go
+++ b/websocket.go
@@ -62,6 +62,7 @@ type wsCmd struct {
 	exitChan     chan int
 	doneChan     chan struct{}
 	receivedExit bool            // true if we received an exit code from server
+	readErr      error           // underlying WebSocket read error, if the connection was interrupted
 	capabilities map[string]bool // Server capabilities from X-Sprite-Capabilities header
 	sessionID    string          // Session ID from session_info message
 
@@ -378,7 +379,7 @@ func (c *wsCmd) waitForSessionInfo() error {
 func (c *wsCmd) Wait() error {
 	select {
 	case <-c.doneChan:
-		return nil
+		return c.readErr
 	case <-c.ctx.Done():
 		return c.ctx.Err()
 	}
@@ -469,6 +470,7 @@ func (c *wsCmd) runIO() {
 		for {
 			messageType, data, err := c.readMessage()
 			if err != nil {
+				c.readErr = err
 				slog.Default().Debug("ws read error", "error", err, "errorType", fmt.Sprintf("%T", err))
 				adapter.Close()
 				if c.ctx.Err() != nil {
@@ -563,6 +565,7 @@ func (c *wsCmd) runIO() {
 	for {
 		messageType, data, err := c.readMessage()
 		if err != nil {
+			c.readErr = err
 			adapter.Close()
 			return
 		}


### PR DESCRIPTION
## Summary

- retain the underlying WebSocket read error when an exec connection ends before an exit frame arrives
- return that error from `Cmd.Wait()` instead of replacing it with the generic `connection closed` error
- preserve WebSocket close codes and reasons for caller-side classification and diagnostics

## Error flow

```text
WebSocket ReadMessage error
           |
           v
      wsCmd.readErr
           |
           v
       wsCmd.Wait
           |
           v
        Cmd.Wait
           |
           v
         caller
```

This does not retry the command, since the server may already have completed it.

Related to superfly/sprite-env#716.
