### PR TITLE
Support resumable exec output

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -78,8 +78,9 @@ type Cmd struct {
 	ttySize *ttySize
 
 	// Session management
-	sessionID   string
-	controlMode bool
+	sessionID    string
+	controlMode  bool
+	outputOffset *int64
 
 	// Control connection for cleanup
 	controlConn *controlConn
@@ -270,6 +271,7 @@ func (c *Cmd) Start() error {
 	c.wsCmd.Tty = c.tty
 	c.wsCmd.IsAttach = c.sessionID != ""
 	c.wsCmd.AttachSessionID = c.sessionID
+	c.wsCmd.OutputOffset = c.outputOffset
 
 	// Set environment and directory
 	c.wsCmd.Env = c.Env
@@ -314,6 +316,8 @@ func (c *Cmd) Start() error {
 			c.setupIO()
 			c.wsCmd.Tty = c.tty
 			c.wsCmd.IsAttach = true
+			c.wsCmd.AttachSessionID = c.sessionID
+			c.wsCmd.OutputOffset = c.outputOffset
 			if c.TextMessageHandler != nil {
 				c.wsCmd.TextMessageHandler = c.TextMessageHandler
 			}
@@ -515,6 +519,21 @@ func (c *Cmd) SetTTY(enable bool) {
 	c.tty = enable
 }
 
+// SetOutputOffset sets the number of stdout and stderr payload bytes already
+// delivered by a non-TTY attachment.
+func (c *Cmd) SetOutputOffset(offset int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.started {
+		panic("sprite: SetOutputOffset after process started")
+	}
+	if offset < 0 {
+		panic("sprite: SetOutputOffset called with a negative offset")
+	}
+	c.outputOffset = &offset
+}
+
 // SetTTYSize sets the terminal size for TTY mode.
 // If called before Start(), it sets the initial size.
 // If called after Start(), it resizes the running terminal.
@@ -675,6 +694,9 @@ func (c *Cmd) buildWebSocketURL() (*url.URL, error) {
 	// Add control mode flag
 	if c.controlMode {
 		q.Set("cc", "true")
+	}
+	if c.outputOffset != nil {
+		q.Set("output_offset", fmt.Sprintf("%d", *c.outputOffset))
 	}
 
 	// Add stdin parameter so the server knows whether to expect input

--- a/exec_test.go
+++ b/exec_test.go
@@ -137,6 +137,40 @@ func TestCmdWaitPreservesWebSocketReadError(t *testing.T) {
 	}
 }
 
+func TestCmdWaitReturnsExecProtocolError(t *testing.T) {
+	const protocolError = "cannot resume output at byte 0: earliest retained byte is 1"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := (&websocket.Upgrader{}).Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_ = conn.WriteJSON(map[string]string{
+			"type":  "error",
+			"error": protocolError,
+		})
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "ws"+strings.TrimPrefix(server.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext() error = %v", err)
+	}
+
+	wsCmd := newWSCmdContext(ctx, req, "true")
+	if err := wsCmd.Start(); err != nil {
+		t.Fatalf("wsCmd.Start() error = %v", err)
+	}
+
+	cmd := &Cmd{started: true, wsCmd: wsCmd}
+	if err := cmd.Wait(); err == nil || err.Error() != protocolError {
+		t.Fatalf("Cmd.Wait() error = %v, want %q", err, protocolError)
+	}
+}
+
 func TestCmdString(t *testing.T) {
 	client := New("test-token", WithBaseURL("http://localhost:8080"))
 	sprite := client.Sprite("my-sprite")
@@ -150,6 +184,7 @@ func TestCmdString(t *testing.T) {
 }
 
 func TestCmdBuildWebSocketURL(t *testing.T) {
+	outputOffset := int64(42)
 	tests := []struct {
 		name              string
 		spriteName        string
@@ -255,11 +290,13 @@ func TestCmdBuildWebSocketURL(t *testing.T) {
 			spriteName:    "my-sprite",
 			serverVersion: "0.1.0", // Release version supports path attach
 			cmd: &Cmd{
-				sessionID: "abc123",
+				sessionID:    "abc123",
+				outputOffset: &outputOffset,
 			},
 			wantPath: "/v1/sprites/my-sprite/exec/abc123",
 			wantQuery: map[string][]string{
-				"stdin": {"false"},
+				"output_offset": {"42"},
+				"stdin":         {"false"},
 			},
 		},
 		{

--- a/session.go
+++ b/session.go
@@ -147,6 +147,12 @@ func (s *Sprite) AttachSessionContext(ctx context.Context, sessionID string) *Cm
 	return s.client.AttachSessionContext(ctx, s.name, sessionID)
 }
 
+// SignalSession sends a signal to an execution session without requiring an
+// active exec WebSocket.
+func (s *Sprite) SignalSession(ctx context.Context, sessionID, signal string) error {
+	return s.client.signalSession(ctx, s.name, sessionID, signal)
+}
+
 // IsSessionActive returns true if the session has recent activity
 func (s *Session) IsSessionActive() bool {
 	if !s.IsActive {

--- a/websocket.go
+++ b/websocket.go
@@ -363,6 +363,7 @@ func (c *wsCmd) waitForSessionInfo() error {
 					if info.Error == "" {
 						info.Error = "exec attach failed"
 					}
+
 					return errors.New(info.Error)
 				}
 				if info.Type == "session_info" {

--- a/websocket.go
+++ b/websocket.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -73,6 +74,9 @@ type wsCmd struct {
 
 	// AttachSessionID is the session ID to attach to (for control connections)
 	AttachSessionID string
+
+	// OutputOffset is the number of non-TTY output payload bytes already delivered.
+	OutputOffset *int64
 
 	// TextMessageHandler is called when text messages are received over the WebSocket
 	TextMessageHandler func([]byte)
@@ -193,6 +197,9 @@ func (c *wsCmd) start() {
 			// For attach operations, include the session ID
 			if c.AttachSessionID != "" {
 				args["id"] = c.AttachSessionID
+			}
+			if c.OutputOffset != nil {
+				args["output_offset"] = strconv.FormatInt(*c.OutputOffset, 10)
 			}
 			// Construct control envelope
 			env := map[string]interface{}{
@@ -349,19 +356,28 @@ func (c *wsCmd) waitForSessionInfo() error {
 				Type      string `json:"type"`
 				TTY       bool   `json:"tty"`
 				SessionID string `json:"session_id"`
+				Error     string `json:"error"`
 			}
-			if err := json.Unmarshal(data, &info); err == nil && info.Type == "session_info" {
-				dbg("sprites: waitForSessionInfo got session_info", "tty", info.TTY, "session_id", info.SessionID)
-				c.Tty = info.TTY
-				if info.SessionID != "" {
-					c.sessionID = info.SessionID
+			if err := json.Unmarshal(data, &info); err == nil {
+				if info.Type == "error" {
+					if info.Error == "" {
+						info.Error = "exec attach failed"
+					}
+					return errors.New(info.Error)
 				}
-				// Call text handler if set
-				if c.TextMessageHandler != nil {
-					c.TextMessageHandler(data)
-				}
+				if info.Type == "session_info" {
+					dbg("sprites: waitForSessionInfo got session_info", "tty", info.TTY, "session_id", info.SessionID)
+					c.Tty = info.TTY
+					if info.SessionID != "" {
+						c.sessionID = info.SessionID
+					}
+					// Call text handler if set
+					if c.TextMessageHandler != nil {
+						c.TextMessageHandler(data)
+					}
 
-				return nil
+					return nil
+				}
 			}
 			// Pass other text messages to handler
 			if c.TextMessageHandler != nil {
@@ -583,6 +599,7 @@ func (c *wsCmd) runIO() {
 				Type      string `json:"type"`
 				SessionID string `json:"session_id,omitempty"`
 				ExitCode  int    `json:"exit_code,omitempty"`
+				Error     string `json:"error,omitempty"`
 			}
 			if json.Unmarshal(data, &msg) == nil {
 				dbg("sprites: non-pty received text message", "type", msg.Type, "data", string(data))
@@ -602,6 +619,17 @@ func (c *wsCmd) runIO() {
 					case c.exitChan <- msg.ExitCode:
 					default:
 					}
+					adapter.Close()
+
+					return
+				case "error":
+					if c.TextMessageHandler != nil {
+						c.TextMessageHandler(data)
+					}
+					if msg.Error == "" {
+						msg.Error = "exec failed"
+					}
+					c.readErr = errors.New(msg.Error)
 					adapter.Close()
 
 					return


### PR DESCRIPTION
## Problem

A non-TTY exec client cannot identify how much stdout and stderr it already delivered when it reattaches after a WebSocket interruption. Server-side resume failures also arrive as generic connection closures, and signals cannot be sent while the exec WebSocket is unavailable.

## Fix

Add an output offset to attach commands for both direct and control connections, preserve explicit exec protocol errors, and expose session signaling independently of the exec WebSocket.

## Supporting information

Companion SDK change for superfly/sprite-env#779.
