### PR TITLE
Keep the Fly request ID on API errors

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -62,7 +62,7 @@ func (c *Client) CreateCheckpointWithComment(ctx context.Context, spriteName str
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
-		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+		return nil, StatusError(resp, body)
 	}
 
 	// Return streaming reader
@@ -131,7 +131,7 @@ func (c *Client) ListCheckpointsWithOptions(ctx context.Context, spriteName stri
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+		return nil, StatusError(resp, body)
 	}
 
 	// Check content type
@@ -185,7 +185,7 @@ func (c *Client) GetCheckpoint(ctx context.Context, spriteName string, checkpoin
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+		return nil, StatusError(resp, body)
 	}
 
 	// Parse response
@@ -228,7 +228,7 @@ func (c *Client) RestoreCheckpoint(ctx context.Context, spriteName string, check
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
-		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+		return nil, StatusError(resp, body)
 	}
 
 	// Return streaming reader

--- a/client.go
+++ b/client.go
@@ -328,7 +328,7 @@ func CreateToken(ctx context.Context, flyMacaroon, orgSlug string, inviteCode st
 			return "", apiErr
 		}
 
-		return "", fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+		return "", StatusError(resp, body)
 	}
 
 	// Parse response

--- a/errors.go
+++ b/errors.go
@@ -2,6 +2,7 @@ package sprites
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -55,6 +56,11 @@ type APIError struct {
 
 	// RateLimitReset is the X-RateLimit-Reset header value (Unix timestamp)
 	RateLimitReset int64 `json:"-"`
+
+	// RequestID is the Fly-Request-Id header, which correlates this call
+	// with sprites-api and fly-proxy logs. Set from the response, never
+	// from the body.
+	RequestID string `json:"-"`
 }
 
 // Error implements the error interface
@@ -104,6 +110,10 @@ func parseAPIError(resp *http.Response, body []byte) *APIError {
 	apiErr := &APIError{
 		StatusCode: resp.StatusCode,
 	}
+
+	// Correlation first: it is the field that stays useful when everything
+	// else about the response is empty.
+	apiErr.RequestID = resp.Header.Get("Fly-Request-Id")
 
 	// Parse rate limit headers
 	if ra := resp.Header.Get("Retry-After"); ra != "" {
@@ -168,4 +178,35 @@ func IsRateLimitErr(err error) *APIError {
 // This is the exported version of parseAPIError for use by clients.
 func ParseAPIError(resp *http.Response, body []byte) *APIError {
 	return parseAPIError(resp, body)
+}
+
+// StatusError renders a non-2xx response in the form callers have always
+// seen, with the Fly request ID appended when the response carried one.
+//
+// Why the text is preserved rather than replaced by APIError.Error(): that
+// method returns only the message, so routing these call sites through it
+// would silently drop the "API returned status NNN" prefix that downstream
+// tooling matches on. The point here is to ADD correlation, not to change
+// what anything already parses.
+//
+// Why it matters: a non-2xx with an empty body renders as the whole of
+//
+//	API returned status 502:
+//
+// and there is nothing in that to find in a log. On one soak run a restore
+// failed exactly that way, and a later search turned up a burst of 21
+// fly-proxy PU02 502s it almost certainly belonged to -- "almost certainly"
+// being where it stopped, because the request ID was sitting in the response
+// this function's callers were discarding. See superfly/sprite-harness#92.
+//
+// Only Fly-Request-Id is added. Copying headers wholesale would eventually
+// echo the Authorization header these requests set, into text that callers
+// print and archive.
+func StatusError(resp *http.Response, body []byte) error {
+	msg := fmt.Sprintf("API returned status %d: %s", resp.StatusCode, string(body))
+	if id := resp.Header.Get("Fly-Request-Id"); id != "" {
+		msg += fmt.Sprintf("\nfly-request-id: %s", id)
+	}
+
+	return errors.New(msg)
 }

--- a/errors_requestid_test.go
+++ b/errors_requestid_test.go
@@ -1,0 +1,98 @@
+package sprites
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// hdr builds a response header set.
+//
+// Returns the header rather than a *http.Response on purpose: bodyclose
+// treats any function returning *http.Response as an HTTP call whose body
+// must be closed, which these header-only fixtures never have. Constructing
+// the response inline at each site keeps the linter satisfied without a
+// suppression comment.
+func hdr(kv map[string]string) http.Header {
+	h := http.Header{}
+	for k, v := range kv {
+		h.Set(k, v)
+	}
+
+	return h
+}
+
+// The motivating case: a non-2xx whose body is empty, so the status line is
+// the entire error. Without the request ID there is nothing to search for.
+func TestStatusErrorAppendsTheRequestIDOnAnEmptyBody(t *testing.T) {
+	resp := &http.Response{StatusCode: 502, Header: hdr(map[string]string{"Fly-Request-Id": "01M19T3EMF8NHCPCPR0YN9ZRYW-lax"})}
+	err := StatusError(resp, nil)
+	if err == nil {
+		t.Fatal("no error returned")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "API returned status 502") {
+		t.Errorf("the established prefix was lost; downstream tooling matches on it: %q", got)
+	}
+	if !strings.Contains(got, "fly-request-id: 01M19T3EMF8NHCPCPR0YN9ZRYW-lax") {
+		t.Errorf("request id not surfaced: %q", got)
+	}
+}
+
+// The text callers have always seen must not change shape when there is no
+// request ID to add.
+func TestStatusErrorIsUnchangedWithoutAHeader(t *testing.T) {
+	err := StatusError(&http.Response{StatusCode: 404, Header: hdr(nil)}, []byte("not found"))
+	if got, want := err.Error(), "API returned status 404: not found"; got != want {
+		t.Errorf("StatusError = %q, want %q", got, want)
+	}
+}
+
+// These requests set an Authorization header, and the result of this
+// function is printed by CLIs and archived by test harnesses. Only the one
+// named header may be copied.
+func TestStatusErrorNeverEchoesCredentials(t *testing.T) {
+	resp := &http.Response{StatusCode: 401, Header: hdr(map[string]string{
+		"Authorization":    "Bearer super-secret-token",
+		"Set-Cookie":       "session=abc123",
+		"WWW-Authenticate": `Bearer realm="sprites"`,
+		"X-Api-Key":        "another-secret",
+		"Fly-Request-Id":   "01M19T3EMF8NHCPCPR0YN9ZRYW-lax",
+	})}
+	got := StatusError(resp, []byte("unauthorized")).Error()
+	for _, secret := range []string{"super-secret-token", "abc123", "another-secret", "realm"} {
+		if strings.Contains(got, secret) {
+			t.Errorf("a credential was echoed into the error text: %q", got)
+		}
+	}
+	if !strings.Contains(got, "01M19T3EMF8NHCPCPR0YN9ZRYW-lax") {
+		t.Error("the request id was dropped along with the credentials")
+	}
+}
+
+// The structured path gets it too, so a caller inspecting *APIError does not
+// have to scrape the string.
+func TestParseAPIErrorCapturesTheRequestID(t *testing.T) {
+	resp := &http.Response{StatusCode: 429, Header: hdr(map[string]string{
+		"Fly-Request-Id": "01M19T3EMF8NHCPCPR0YN9ZRYW-ord",
+		"Retry-After":    "30",
+	})}
+	apiErr := parseAPIError(resp, []byte(`{"error":"sprite_creation_rate_limited","message":"slow down"}`))
+	if apiErr == nil {
+		t.Fatal("no APIError parsed")
+	}
+	if apiErr.RequestID != "01M19T3EMF8NHCPCPR0YN9ZRYW-ord" {
+		t.Errorf("RequestID = %q", apiErr.RequestID)
+	}
+	// And the existing behaviour is untouched.
+	if !apiErr.IsRateLimitError() || apiErr.GetRetryAfterSeconds() != 30 {
+		t.Errorf("existing APIError parsing regressed: %+v", apiErr)
+	}
+}
+
+// A 2xx is not an error, and must not acquire one.
+func TestParseAPIErrorStillIgnoresSuccess(t *testing.T) {
+	if got := parseAPIError(&http.Response{StatusCode: 200, Header: hdr(map[string]string{"Fly-Request-Id": "x"})}, nil); got != nil {
+		t.Errorf("parseAPIError on a 200 returned %+v, want nil", got)
+	}
+}

--- a/policy.go
+++ b/policy.go
@@ -28,7 +28,7 @@ func (c *Client) GetNetworkPolicy(ctx context.Context, spriteName string) (*Netw
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+		return nil, StatusError(resp, body)
 	}
 
 	var policy NetworkPolicy
@@ -74,7 +74,7 @@ func (c *Client) UpdateNetworkPolicy(ctx context.Context, spriteName string, pol
 
 	if resp.StatusCode != http.StatusNoContent {
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+		return StatusError(resp, body)
 	}
 
 	return nil

--- a/services.go
+++ b/services.go
@@ -96,7 +96,7 @@ func (c *Client) ListServices(ctx context.Context, spriteName string) ([]*Servic
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+		return nil, StatusError(resp, body)
 	}
 
 	var services []*ServiceWithState
@@ -136,7 +136,7 @@ func (c *Client) GetService(ctx context.Context, spriteName, serviceName string)
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+		return nil, StatusError(resp, body)
 	}
 
 	var service ServiceWithState
@@ -196,7 +196,7 @@ func (c *Client) CreateServiceWithDuration(ctx context.Context, spriteName, serv
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
-		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+		return nil, StatusError(resp, body)
 	}
 
 	return &ServiceStream{
@@ -244,7 +244,7 @@ func (c *Client) DeleteService(ctx context.Context, spriteName, serviceName stri
 
 	if resp.StatusCode != http.StatusNoContent {
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+		return StatusError(resp, body)
 	}
 
 	return nil
@@ -293,7 +293,7 @@ func (c *Client) StartServiceWithDuration(ctx context.Context, spriteName, servi
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
-		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+		return nil, StatusError(resp, body)
 	}
 
 	return &ServiceStream{
@@ -356,7 +356,7 @@ func (c *Client) StopServiceWithTimeout(ctx context.Context, spriteName, service
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
-		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+		return nil, StatusError(resp, body)
 	}
 
 	return &ServiceStream{
@@ -423,7 +423,7 @@ func (c *Client) SignalService(ctx context.Context, spriteName, serviceName, sig
 
 	if resp.StatusCode != http.StatusNoContent {
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+		return StatusError(resp, body)
 	}
 
 	return nil

--- a/session.go
+++ b/session.go
@@ -37,7 +37,7 @@ func (c *Client) ListSessions(ctx context.Context, spriteName string) ([]*Sessio
 	// Check status
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+		return nil, StatusError(resp, body)
 	}
 
 	// Parse response


### PR DESCRIPTION
Fixes the client half of superfly/sprite-harness#92.

## The problem

A non-2xx was rendered with only its status and body:

```go
return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
```

When the body is empty, that is the **whole** error:

```
API returned status 502:
```

There is nothing in that anyone can look up. Meanwhile `resp.Header` was in scope and discarded — and every response from `api.sprites.dev` carries a `Fly-Request-Id`, including the error paths:

```
$ curl -sS -o /dev/null -D - https://api.sprites.dev/
HTTP/2 404
server: Fly/ec1a4f957c (2026-08-31)
via: 2 fly.io, 2 fly.io
fly-request-id: 01M1CAEP1Z2PWW8S1W77N1WDVE-lax
```

## Why it came up

A checkpoint/restore soak run hit exactly this. Sprite `sbd-y4wem-r313`, restore of `v1`, failed after 14.9s with an empty 502. A later log search turned up a burst of 21 fly-proxy `PU02` 502s spanning 17:04:43Z–17:04:51Z that it almost certainly belonged to — and *almost certainly* was as far as it got, because the request ID that would have pinned it to an exact request and API instance was sitting in the response this code was holding.

Across every error captured by that harness — 17,143 blobs — **559 carried an HTTP status and zero carried a request ID.**

## The change

`StatusError(resp, body)` renders the text callers have always seen, and appends the request ID when the response carried one. All **15** call sites move to it: `checkpoint.go` ×4, `services.go` ×7, `policy.go` ×2, `client.go`, `session.go`.

```
API returned status 502:
fly-request-id: 01M19T3EMF8NHCPCPR0YN9ZRYW-lax
```

**Deliberately not routed through `APIError.Error()`**, which returns only the message — that would drop the `API returned status NNN` prefix that downstream tooling matches on. The aim is to *add* correlation, not to change what anything already parses. A caller whose response has no request ID sees byte-identical output.

`parseAPIError` also records `RequestID`, so a caller inspecting `*APIError` need not scrape the string. Existing rate-limit parsing is untouched and covered by a test.

## Security

Only `Fly-Request-Id` is copied, never headers in bulk. These requests set an `Authorization` header (`checkpoint.go:177`), and this text is printed by CLIs and archived by test harnesses — a helper that copied headers wholesale would eventually put a bearer token in a log. `TestStatusErrorNeverEchoesCredentials` pins that.

## Tests

Five new, all confirmed failing before the change:

- request ID appended on an empty body, with the established prefix intact
- output byte-identical when no request-ID header is present
- credentials never echoed (`Authorization`, `Set-Cookie`, `WWW-Authenticate`, `X-Api-Key`)
- `parseAPIError` captures `RequestID` without regressing rate-limit handling
- a 2xx still parses to no error

`go build ./...` and `go test ./...` green.

## Scope note

The diff is exactly the 15 one-line swaps plus `errors.go`, additive only — zero deleted lines.

Rebased onto current `main`. My first push was branched from the commit `sprite-env` pins as its submodule, which was 22 commits behind; the tree is gofmt-clean and `nlreturn`-clean on current main, so the earlier note about formatting churn in this repo does not apply — please disregard it.

There are 2 further call sites of the same pattern in `superfly/sprite-env` (`client/fly/manager.go`, `client/commands/flyctl_auth.go`). Those build their own HTTP requests rather than using this SDK; happy to follow up there once this lands.
