### PR TITLE
Preserve request IDs on stream failures

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -13,16 +13,18 @@ import (
 
 // CheckpointStream represents a streaming checkpoint operation
 type CheckpointStream struct {
-	reader  io.ReadCloser
-	scanner *bufio.Scanner
-	done    bool
+	reader    io.ReadCloser
+	scanner   *bufio.Scanner
+	done      bool
+	requestID string
 }
 
 // RestoreStream represents a streaming restore operation
 type RestoreStream struct {
-	reader  io.ReadCloser
-	scanner *bufio.Scanner
-	done    bool
+	reader    io.ReadCloser
+	scanner   *bufio.Scanner
+	done      bool
+	requestID string
 }
 
 // CreateCheckpointWithComment creates a new checkpoint for the sprite with an optional comment
@@ -67,8 +69,9 @@ func (c *Client) CreateCheckpointWithComment(ctx context.Context, spriteName str
 
 	// Return streaming reader
 	return &CheckpointStream{
-		reader:  resp.Body,
-		scanner: bufio.NewScanner(resp.Body),
+		reader:    resp.Body,
+		scanner:   bufio.NewScanner(resp.Body),
+		requestID: resp.Header.Get("Fly-Request-Id"),
 	}, nil
 }
 
@@ -233,8 +236,9 @@ func (c *Client) RestoreCheckpoint(ctx context.Context, spriteName string, check
 
 	// Return streaming reader
 	return &RestoreStream{
-		reader:  resp.Body,
-		scanner: bufio.NewScanner(resp.Body),
+		reader:    resp.Body,
+		scanner:   bufio.NewScanner(resp.Body),
+		requestID: resp.Header.Get("Fly-Request-Id"),
 	}, nil
 }
 
@@ -252,7 +256,7 @@ func (cs *CheckpointStream) Next() (*StreamMessage, error) {
 	if !cs.scanner.Scan() {
 		cs.done = true
 		if err := cs.scanner.Err(); err != nil {
-			return nil, err
+			return nil, withRequestID(err, cs.requestID)
 		}
 
 		return nil, io.EOF
@@ -266,7 +270,7 @@ func (cs *CheckpointStream) Next() (*StreamMessage, error) {
 
 	var msg StreamMessage
 	if err := json.Unmarshal([]byte(line), &msg); err != nil {
-		return nil, fmt.Errorf("failed to parse message: %w", err)
+		return nil, withRequestID(fmt.Errorf("failed to parse message: %w", err), cs.requestID)
 	}
 
 	return &msg, nil
@@ -290,7 +294,7 @@ func (rs *RestoreStream) Next() (*StreamMessage, error) {
 	if !rs.scanner.Scan() {
 		rs.done = true
 		if err := rs.scanner.Err(); err != nil {
-			return nil, err
+			return nil, withRequestID(err, rs.requestID)
 		}
 
 		return nil, io.EOF
@@ -304,7 +308,7 @@ func (rs *RestoreStream) Next() (*StreamMessage, error) {
 
 	var msg StreamMessage
 	if err := json.Unmarshal([]byte(line), &msg); err != nil {
-		return nil, fmt.Errorf("failed to parse message: %w", err)
+		return nil, withRequestID(fmt.Errorf("failed to parse message: %w", err), rs.requestID)
 	}
 
 	return &msg, nil

--- a/checkpoint_requestid_test.go
+++ b/checkpoint_requestid_test.go
@@ -1,0 +1,162 @@
+package sprites
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+var errStreamInterrupted = errors.New("stream interrupted")
+
+type failingStreamBody struct{}
+
+func (failingStreamBody) Read([]byte) (int, error) {
+	return 0, errStreamInterrupted
+}
+
+func (failingStreamBody) Close() error {
+	return nil
+}
+
+type streamRoundTripper struct {
+	requestID string
+	body      io.ReadCloser
+}
+
+func (rt streamRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header: hdr(map[string]string{
+			"Fly-Request-Id": rt.requestID,
+		}),
+		Body: rt.body,
+	}, nil
+}
+
+type messageStream interface {
+	Next() (*StreamMessage, error)
+	ProcessAll(func(*StreamMessage) error) error
+}
+
+func TestCheckpointAndRestoreStreamErrorsIncludeRequestID(t *testing.T) {
+	const requestID = "01M19T3EMF8NHCPCPR0YN9ZRYW-lax"
+
+	streamTypes := []struct {
+		name string
+		open func(*Client) (messageStream, error)
+	}{
+		{
+			name: "checkpoint",
+			open: func(client *Client) (messageStream, error) {
+				return client.CreateCheckpoint(context.Background(), "test-sprite")
+			},
+		},
+		{
+			name: "restore",
+			open: func(client *Client) (messageStream, error) {
+				return client.RestoreCheckpoint(context.Background(), "test-sprite", "test-checkpoint")
+			},
+		},
+	}
+
+	operations := []struct {
+		name string
+		run  func(messageStream) error
+	}{
+		{
+			name: "Next",
+			run: func(stream messageStream) error {
+				_, err := stream.Next()
+				return err
+			},
+		},
+		{
+			name: "ProcessAll",
+			run: func(stream messageStream) error {
+				return stream.ProcessAll(func(*StreamMessage) error {
+					return errors.New("handler called for a failed stream")
+				})
+			},
+		},
+	}
+	failures := []struct {
+		name string
+		body func() io.ReadCloser
+		want string
+	}{
+		{
+			name: "read error",
+			body: func() io.ReadCloser { return failingStreamBody{} },
+			want: errStreamInterrupted.Error(),
+		},
+		{
+			name: "truncated JSON",
+			body: func() io.ReadCloser { return io.NopCloser(strings.NewReader(`{"type":`)) },
+			want: "failed to parse message",
+		},
+	}
+
+	for _, streamType := range streamTypes {
+		for _, operation := range operations {
+			for _, failure := range failures {
+				t.Run(streamType.name+"/"+operation.name+"/"+failure.name, func(t *testing.T) {
+					client := New("test-token", WithHTTPClient(&http.Client{
+						Transport: streamRoundTripper{requestID: requestID, body: failure.body()},
+					}))
+					stream, err := streamType.open(client)
+					if err != nil {
+						t.Fatalf("open stream: %v", err)
+					}
+
+					err = operation.run(stream)
+					if !strings.Contains(err.Error(), failure.want) {
+						t.Fatalf("error = %q, want text %q", err, failure.want)
+					}
+					if failure.name == "read error" && !errors.Is(err, errStreamInterrupted) {
+						t.Fatalf("error = %v, want wrapped stream error", err)
+					}
+					if !strings.Contains(err.Error(), "fly-request-id: "+requestID) {
+						t.Fatalf("request ID not surfaced: %q", err)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestStreamErrorWithoutRequestIDIsUnchanged(t *testing.T) {
+	streams := []struct {
+		name   string
+		stream messageStream
+	}{
+		{
+			name: "checkpoint",
+			stream: &CheckpointStream{
+				reader:  failingStreamBody{},
+				scanner: bufio.NewScanner(failingStreamBody{}),
+			},
+		},
+		{
+			name: "restore",
+			stream: &RestoreStream{
+				reader:  failingStreamBody{},
+				scanner: bufio.NewScanner(failingStreamBody{}),
+			},
+		},
+	}
+
+	for _, tt := range streams {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.stream.Next()
+			if err != errStreamInterrupted {
+				t.Fatalf("error = %v, want the original error", err)
+			}
+		})
+	}
+}
+
+var _ io.ReadCloser = failingStreamBody{}

--- a/errors.go
+++ b/errors.go
@@ -210,3 +210,14 @@ func StatusError(resp *http.Response, body []byte) error {
 
 	return errors.New(msg)
 }
+
+// withRequestID adds response correlation to an error while preserving the
+// original error for errors.Is/errors.As. Errors without a request ID retain
+// their original identity and text.
+func withRequestID(err error, requestID string) error {
+	if requestID == "" {
+		return err
+	}
+
+	return fmt.Errorf("%w\nfly-request-id: %s", err, requestID)
+}

--- a/services.go
+++ b/services.go
@@ -13,9 +13,10 @@ import (
 
 // ServiceStream represents a streaming service operation (start/stop/create)
 type ServiceStream struct {
-	reader  io.ReadCloser
-	scanner *bufio.Scanner
-	done    bool
+	reader    io.ReadCloser
+	scanner   *bufio.Scanner
+	done      bool
+	requestID string
 }
 
 // Next reads the next log event from the service stream
@@ -27,7 +28,7 @@ func (ss *ServiceStream) Next() (*ServiceLogEvent, error) {
 	if !ss.scanner.Scan() {
 		ss.done = true
 		if err := ss.scanner.Err(); err != nil {
-			return nil, err
+			return nil, withRequestID(err, ss.requestID)
 		}
 
 		return nil, io.EOF
@@ -41,7 +42,7 @@ func (ss *ServiceStream) Next() (*ServiceLogEvent, error) {
 
 	var event ServiceLogEvent
 	if err := json.Unmarshal([]byte(line), &event); err != nil {
-		return nil, fmt.Errorf("failed to parse service log event: %w", err)
+		return nil, withRequestID(fmt.Errorf("failed to parse service log event: %w", err), ss.requestID)
 	}
 
 	return &event, nil
@@ -200,8 +201,9 @@ func (c *Client) CreateServiceWithDuration(ctx context.Context, spriteName, serv
 	}
 
 	return &ServiceStream{
-		reader:  resp.Body,
-		scanner: bufio.NewScanner(resp.Body),
+		reader:    resp.Body,
+		scanner:   bufio.NewScanner(resp.Body),
+		requestID: resp.Header.Get("Fly-Request-Id"),
 	}, nil
 }
 
@@ -297,8 +299,9 @@ func (c *Client) StartServiceWithDuration(ctx context.Context, spriteName, servi
 	}
 
 	return &ServiceStream{
-		reader:  resp.Body,
-		scanner: bufio.NewScanner(resp.Body),
+		reader:    resp.Body,
+		scanner:   bufio.NewScanner(resp.Body),
+		requestID: resp.Header.Get("Fly-Request-Id"),
 	}, nil
 }
 
@@ -360,8 +363,9 @@ func (c *Client) StopServiceWithTimeout(ctx context.Context, spriteName, service
 	}
 
 	return &ServiceStream{
-		reader:  resp.Body,
-		scanner: bufio.NewScanner(resp.Body),
+		reader:    resp.Body,
+		scanner:   bufio.NewScanner(resp.Body),
+		requestID: resp.Header.Get("Fly-Request-Id"),
 	}, nil
 }
 

--- a/services_requestid_test.go
+++ b/services_requestid_test.go
@@ -1,0 +1,92 @@
+package sprites
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestServiceStreamErrorsIncludeRequestID(t *testing.T) {
+	const requestID = "01M19T3EMF8NHCPCPR0YN9ZRYW-ord"
+
+	operations := []struct {
+		name string
+		open func(*Client) (*ServiceStream, error)
+	}{
+		{
+			name: "create",
+			open: func(client *Client) (*ServiceStream, error) {
+				return client.CreateService(context.Background(), "test-sprite", "test-service", &ServiceRequest{})
+			},
+		},
+		{
+			name: "start",
+			open: func(client *Client) (*ServiceStream, error) {
+				return client.StartService(context.Background(), "test-sprite", "test-service")
+			},
+		},
+		{
+			name: "stop",
+			open: func(client *Client) (*ServiceStream, error) {
+				return client.StopService(context.Background(), "test-sprite", "test-service")
+			},
+		},
+	}
+	failures := []struct {
+		name string
+		body func() io.ReadCloser
+		want string
+	}{
+		{
+			name: "read error",
+			body: func() io.ReadCloser { return failingStreamBody{} },
+			want: errStreamInterrupted.Error(),
+		},
+		{
+			name: "truncated JSON",
+			body: func() io.ReadCloser { return io.NopCloser(strings.NewReader(`{"type":`)) },
+			want: "failed to parse service log event",
+		},
+	}
+
+	for _, operation := range operations {
+		for _, failure := range failures {
+			t.Run(operation.name+"/"+failure.name, func(t *testing.T) {
+				client := New("test-token", WithHTTPClient(&http.Client{
+					Transport: streamRoundTripper{requestID: requestID, body: failure.body()},
+				}))
+				stream, err := operation.open(client)
+				if err != nil {
+					t.Fatalf("open stream: %v", err)
+				}
+
+				_, err = stream.Next()
+				if !strings.Contains(err.Error(), failure.want) {
+					t.Fatalf("error = %q, want text %q", err, failure.want)
+				}
+				if failure.name == "read error" && !errors.Is(err, errStreamInterrupted) {
+					t.Fatalf("error = %v, want wrapped stream error", err)
+				}
+				if !strings.Contains(err.Error(), "fly-request-id: "+requestID) {
+					t.Fatalf("request ID not surfaced: %q", err)
+				}
+			})
+		}
+	}
+}
+
+func TestServiceStreamErrorWithoutRequestIDIsUnchanged(t *testing.T) {
+	stream := &ServiceStream{
+		reader:  failingStreamBody{},
+		scanner: bufio.NewScanner(failingStreamBody{}),
+	}
+
+	_, err := stream.Next()
+	if err != errStreamInterrupted {
+		t.Fatalf("error = %v, want the original error", err)
+	}
+}


### PR DESCRIPTION
## Summary
- retain Fly-Request-Id on checkpoint and restore streams
- attach correlation IDs to scanner errors and truncated JSON parse failures
- apply the same behavior to create, start, and stop service streams
- preserve original error identity when no request ID is present

## User impact
Operators can correlate mid-stream checkpoint, restore, and service failures with Fly logs instead of receiving an untraceable transport or parse error. Successful streams and errors without a request ID are unchanged.

Closes #36