### PR TITLE
Let callers choose a runtime when creating a sprite

### DIFF
--- a/management.go
+++ b/management.go
@@ -11,6 +11,18 @@ import (
 	"strconv"
 )
 
+// CreateSpriteOptions carries the optional settings for creating a sprite.
+//
+// It exists so that new settings can be added without changing the signature
+// of an exported function; the zero value asks for a default sprite.
+type CreateSpriteOptions struct {
+	Config *SpriteConfig
+	Org    *OrganizationInfo
+	Labels []string
+	// Runtime selects a server-side runtime variant. See CreateSpriteRequest.
+	Runtime string
+}
+
 // CreateSprite creates a new sprite with the given name and optional configuration
 func (c *Client) CreateSprite(ctx context.Context, name string, config *SpriteConfig) (*Sprite, error) {
 	return c.CreateSpriteWithOrg(ctx, name, config, nil, nil)
@@ -18,10 +30,24 @@ func (c *Client) CreateSprite(ctx context.Context, name string, config *SpriteCo
 
 // CreateSpriteWithOrg creates a new sprite with the given name, optional configuration, organization information, and labels
 func (c *Client) CreateSpriteWithOrg(ctx context.Context, name string, config *SpriteConfig, org *OrganizationInfo, labels []string) (*Sprite, error) {
-	req := CreateSpriteRequest{
-		Name:   name,
+	return c.CreateSpriteWithOptions(ctx, name, CreateSpriteOptions{
 		Config: config,
+		Org:    org,
 		Labels: labels,
+	})
+}
+
+// CreateSpriteWithOptions creates a new sprite, taking its optional settings as
+// a struct. Prefer it over CreateSprite and CreateSpriteWithOrg, which remain
+// for compatibility and delegate here.
+func (c *Client) CreateSpriteWithOptions(ctx context.Context, name string, opts CreateSpriteOptions) (*Sprite, error) {
+	org := opts.Org
+
+	req := CreateSpriteRequest{
+		Name:    name,
+		Config:  opts.Config,
+		Labels:  opts.Labels,
+		Runtime: opts.Runtime,
 	}
 
 	jsonData, err := json.Marshal(req)

--- a/management_runtime_test.go
+++ b/management_runtime_test.go
@@ -42,6 +42,7 @@ func TestCreateSpriteWithOptionsSendsRuntime(t *testing.T) {
 		_, err := c.CreateSpriteWithOptions(context.Background(), "test-sprite", CreateSpriteOptions{
 			Runtime: "some-runtime",
 		})
+
 		return err
 	})
 

--- a/management_runtime_test.go
+++ b/management_runtime_test.go
@@ -1,0 +1,85 @@
+package sprites
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// captureCreateRequest runs a create against a stub server and returns the
+// decoded request body it received.
+func captureCreateRequest(t *testing.T, create func(c *Client) error) map[string]any {
+	t.Helper()
+
+	var body map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("reading request body: %v", err)
+		}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Errorf("decoding request body %q: %v", raw, err)
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"name":"test-sprite"}`))
+	}))
+	defer srv.Close()
+
+	if err := create(New("test-token", WithBaseURL(srv.URL))); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	return body
+}
+
+func TestCreateSpriteWithOptionsSendsRuntime(t *testing.T) {
+	body := captureCreateRequest(t, func(c *Client) error {
+		_, err := c.CreateSpriteWithOptions(context.Background(), "test-sprite", CreateSpriteOptions{
+			Runtime: "some-runtime",
+		})
+		return err
+	})
+
+	if got := body["runtime"]; got != "some-runtime" {
+		t.Errorf("runtime = %v, want %q", got, "some-runtime")
+	}
+}
+
+func TestCreateSpriteOmitsEmptyRuntime(t *testing.T) {
+	// An explicit empty runtime would ask the API for a variant named "",
+	// rather than for the default one, so the field has to disappear.
+	body := captureCreateRequest(t, func(c *Client) error {
+		_, err := c.CreateSprite(context.Background(), "test-sprite", nil)
+		return err
+	})
+
+	if _, present := body["runtime"]; present {
+		t.Errorf("runtime present in body %v, want it omitted", body)
+	}
+}
+
+func TestCreateSpriteWithOrgStillCarriesItsArguments(t *testing.T) {
+	body := captureCreateRequest(t, func(c *Client) error {
+		_, err := c.CreateSpriteWithOrg(context.Background(), "test-sprite",
+			&SpriteConfig{RamMB: 2048}, nil, []string{"a-label"})
+		return err
+	})
+
+	config, ok := body["config"].(map[string]any)
+	if !ok {
+		t.Fatalf("config = %v, want an object", body["config"])
+	}
+	if got := config["ram_mb"]; got != float64(2048) {
+		t.Errorf("config.ram_mb = %v, want 2048", got)
+	}
+
+	labels, ok := body["labels"].([]any)
+	if !ok || len(labels) != 1 || labels[0] != "a-label" {
+		t.Errorf("labels = %v, want [a-label]", body["labels"])
+	}
+}

--- a/types.go
+++ b/types.go
@@ -43,6 +43,11 @@ type CreateSpriteRequest struct {
 	Config      *SpriteConfig     `json:"config,omitempty"`
 	Environment map[string]string `json:"environment,omitempty"`
 	Labels      []string          `json:"labels,omitempty"`
+	// Runtime selects a server-side runtime variant for the sprite. Valid
+	// values are defined by the API rather than this SDK, so new ones become
+	// usable without an SDK release; an unknown value is rejected by the
+	// server with the set it accepts. Empty means the default runtime.
+	Runtime string `json:"runtime,omitempty"`
 }
 
 // UpdateSpriteRequest represents the request to update a sprite's settings


### PR DESCRIPTION
The create API accepts an optional `runtime` naming which runtime variant a sprite should be created on. The SDK had no way to send it, so callers were stuck with the default.

## Shape

Rather than grow the signature of `CreateSpriteWithOrg` a third time, this adds `CreateSpriteWithOptions` taking a `CreateSpriteOptions` struct, so the next optional setting is a field rather than another positional argument:

```go
sprite, err := client.CreateSpriteWithOptions(ctx, "my-sprite", sprites.CreateSpriteOptions{
    Runtime: "some-runtime",
})
```

`CreateSprite` and `CreateSpriteWithOrg` are untouched at the call site and delegate to it, so this is additive — no existing caller has to change.

## The runtime is opaque on purpose

Which names are valid is the API's business, not the SDK's. Keeping it an unvalidated string means a new runtime works without an SDK release, and an unknown one comes back as a server error naming the set that is accepted — better than a client-side list that drifts out of date and rejects something the server would have taken.

An empty runtime is omitted from the request body entirely (`omitempty`), since sending `""` would ask for a variant named `""` rather than for the default. There is a test pinning that, because it is the kind of thing a later refactor silently breaks.

## Tests

Three, driving a stub server and asserting on the JSON that actually goes out: the runtime is sent when set, omitted when empty, and `CreateSpriteWithOrg` still carries its config and labels through the new path. `go test`, `go vet` and `gofmt` are clean.