### PR TITLE
Surface validation errors reported as a list

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 )
 
 // Error codes returned by the API for rate limiting
@@ -23,6 +24,11 @@ type APIError struct {
 
 	// Message is the human-readable error message
 	Message string `json:"message"`
+
+	// Errors holds the messages from endpoints that report validation
+	// failures as a list rather than as a single message — a create
+	// rejected for several reasons at once returns one entry per reason.
+	Errors []string `json:"errors"`
 
 	// Limit is the rate limit value (e.g., 10 sprites per minute)
 	Limit int `json:"limit,omitempty"`
@@ -70,6 +76,11 @@ func (e *APIError) Error() string {
 	}
 	if e.ErrorCode != "" {
 		return e.ErrorCode
+	}
+	// Validation failures arrive only as a list. Without this the reason the
+	// server gave is dropped and the caller is left with the bare status.
+	if joined := strings.Join(e.Errors, "; "); joined != "" {
+		return joined
 	}
 
 	return fmt.Sprintf("API error (status %d)", e.StatusCode)
@@ -146,7 +157,7 @@ func parseAPIError(resp *http.Response, body []byte) *APIError {
 	}
 
 	// Fallback message if nothing was parsed
-	if apiErr.Message == "" && apiErr.ErrorCode == "" {
+	if apiErr.Message == "" && apiErr.ErrorCode == "" && len(apiErr.Errors) == 0 {
 		apiErr.Message = fmt.Sprintf("API error (status %d)", resp.StatusCode)
 	}
 

--- a/errors_list_test.go
+++ b/errors_list_test.go
@@ -1,0 +1,83 @@
+package sprites
+
+import (
+	"net/http"
+	"testing"
+)
+
+// errorFromBody builds an APIError the way a real response would.
+func errorFromBody(t *testing.T, status int, body string) *APIError {
+	t.Helper()
+
+	resp := &http.Response{StatusCode: status, Header: http.Header{}}
+
+	apiErr := parseAPIError(resp, []byte(body))
+	if apiErr == nil {
+		t.Fatalf("parseAPIError returned nil for status %d", status)
+	}
+
+	return apiErr
+}
+
+func TestAPIErrorReadsErrorList(t *testing.T) {
+	// Validation failures are reported as a list, and until this was parsed
+	// the reason was dropped and callers saw only the status.
+	apiErr := errorFromBody(t, http.StatusBadRequest,
+		`{"errors":["invalid runtime: nope, must be \"default\" or \"dev\""]}`)
+
+	if got, want := apiErr.Error(), `invalid runtime: nope, must be "default" or "dev"`; got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+
+	if len(apiErr.Errors) != 1 {
+		t.Errorf("Errors = %v, want one entry", apiErr.Errors)
+	}
+}
+
+func TestAPIErrorJoinsSeveralErrors(t *testing.T) {
+	apiErr := errorFromBody(t, http.StatusBadRequest,
+		`{"errors":["name is required","invalid region"]}`)
+
+	if got, want := apiErr.Error(), "name is required; invalid region"; got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestAPIErrorPrefersMessageOverList(t *testing.T) {
+	// A body carrying both should read as the singular message; the list is
+	// still exposed for a caller that wants every reason.
+	apiErr := errorFromBody(t, http.StatusBadRequest,
+		`{"message":"the headline","errors":["a detail"]}`)
+
+	if got, want := apiErr.Error(), "the headline"; got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+	if len(apiErr.Errors) != 1 || apiErr.Errors[0] != "a detail" {
+		t.Errorf("Errors = %v, want [a detail]", apiErr.Errors)
+	}
+}
+
+func TestAPIErrorKeepsSingularShapes(t *testing.T) {
+	// The shapes that already worked must keep working.
+	if got := errorFromBody(t, http.StatusBadRequest, `{"error":"name is required"}`).Error(); got != "name is required" {
+		t.Errorf("Error() = %q, want %q", got, "name is required")
+	}
+
+	if got := errorFromBody(t, http.StatusTooManyRequests,
+		`{"error":"sprite_creation_rate_limited","message":"slow down"}`).Error(); got != "slow down" {
+		t.Errorf("Error() = %q, want %q", got, "slow down")
+	}
+}
+
+func TestAPIErrorFallsBackWithoutAnyMessage(t *testing.T) {
+	if got, want := errorFromBody(t, http.StatusInternalServerError, `{}`).Error(),
+		"API error (status 500)"; got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+
+	// An empty list is not a message either.
+	if got, want := errorFromBody(t, http.StatusInternalServerError, `{"errors":[]}`).Error(),
+		"API error (status 500)"; got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}

--- a/errors_list_test.go
+++ b/errors_list_test.go
@@ -23,9 +23,9 @@ func TestAPIErrorReadsErrorList(t *testing.T) {
 	// Validation failures are reported as a list, and until this was parsed
 	// the reason was dropped and callers saw only the status.
 	apiErr := errorFromBody(t, http.StatusBadRequest,
-		`{"errors":["invalid runtime: nope, must be \"default\" or \"dev\""]}`)
+		`{"errors":["name must be lowercase alphanumeric"]}`)
 
-	if got, want := apiErr.Error(), `invalid runtime: nope, must be "default" or "dev"`; got != want {
+	if got, want := apiErr.Error(), "name must be lowercase alphanumeric"; got != want {
 		t.Errorf("Error() = %q, want %q", got, want)
 	}
 


### PR DESCRIPTION
Some endpoints report a failed request as a single message, and some report it as a list of them — a request rejected for several reasons at once returns one entry per reason. `APIError` only understood the singular shape:

```go
ErrorCode string `json:"error"`
Message   string `json:"message"`
```

A list body unmarshals cleanly into that (unknown fields are ignored), leaving both fields empty, so `Error()` fell through to its bare-status fallback. The server said exactly what was wrong and the SDK dropped it, leaving callers with:

```
API error (status 400)
```

and no way to find out why short of capturing the raw body by hand. That is how this was found.

## The change

`APIError` gains `Errors []string`, and `Error()` falls back to joining it with `"; "` before the bare-status fallback. Precedence is unchanged for everything that already worked:

1. `Message`, when present
2. `ErrorCode`, when present
3. **`Errors`, joined** ← new
4. `API error (status N)`

So a body carrying both a message and a list still reads as its message, and the list stays available for a caller that wants every reason. The "nothing was parsed" fallback now also counts a populated list as parsed.

An empty `"errors": []` is deliberately not treated as a message — it would otherwise produce an empty error string, which is worse than the status.

## Tests

Five cases: the single-entry list, several entries joined, message-wins-over-list, the singular shapes still working (including the rate-limit one), and both fallbacks. `go test`, `go vet` and `golangci-lint v2.11.3` are clean.